### PR TITLE
feat: testes unitários e atualização da documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,101 @@
-# Carlessopilatesfe
+# Carlesso Pilates — Frontend
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.2.24.
+Interface web para gestão administrativa de um estúdio de pilates, desenvolvida em **Angular 19**.
 
-## Development server
+## Visão Geral
 
-To start a local development server, run:
+A aplicação oferece um CRUD completo de pacientes com listagem paginada, formulário de cadastro/edição e visualização detalhada. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
 
-```bash
-ng serve
-```
+**Documentação detalhada:** [`docs/documentacao.md`](docs/documentacao.md)  
+**Contexto e decisões técnicas:** [`docs/context.md`](docs/context.md)
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+---
 
-## Code scaffolding
+## Pré-requisitos
 
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
+- Node.js 18+
+- Angular CLI: `npm install -g @angular/cli`
+- Backend rodando em `http://localhost:8080`
 
-```bash
-ng generate component component-name
-```
+---
 
-For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
-
-```bash
-ng generate --help
-```
-
-## Building
-
-To build the project run:
+## Instalação
 
 ```bash
-ng build
+npm install
 ```
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+---
 
-## Running unit tests
+## Scripts
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+| Comando         | Descrição                                          |
+|-----------------|----------------------------------------------------|
+| `npm start`     | Servidor de desenvolvimento em http://localhost:4200 |
+| `npm test`      | Executa testes unitários (Karma + Jasmine)         |
+| `npm run build` | Build de produção em `dist/carlessopilatesfe`      |
+| `npm run watch` | Build contínuo em modo desenvolvimento             |
+
+---
+
+## Stack
+
+| Camada     | Tecnologia                    |
+|------------|-------------------------------|
+| Framework  | Angular 19.2 (standalone)     |
+| Linguagem  | TypeScript 5.7                |
+| Estilos    | SCSS                          |
+| Forms      | Reactive Forms                |
+| HTTP       | HttpClient + proxy `/api/*`   |
+| Testes     | Karma + Jasmine               |
+
+---
+
+## Estrutura
+
+```
+src/app/
+├── core/
+│   ├── models/paciente.ts          # DTOs e interfaces
+│   └── services/paciente.service.ts # Integração com a API REST
+├── pages/pacientes/
+│   ├── paciente-list/              # Listagem paginada
+│   ├── paciente-form/              # Cadastro e edição
+│   └── paciente-detail/            # Visualização detalhada
+└── shared/components/              # Componentes reutilizáveis
+```
+
+---
+
+## Testes
+
+Os testes unitários cobrem o serviço e todos os componentes de página:
 
 ```bash
-ng test
+npm test
 ```
 
-## Running end-to-end tests
+Arquivos de teste:
+- `src/app/app.component.spec.ts`
+- `src/app/core/services/paciente.service.spec.ts`
+- `src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts`
+- `src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts`
+- `src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts`
 
-For end-to-end (e2e) testing, run:
+---
 
-```bash
-ng e2e
-```
+## Rotas
 
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
+| Caminho                 | Função                         |
+|-------------------------|--------------------------------|
+| `/`                     | Redireciona para `/pacientes`  |
+| `/pacientes`            | Lista de pacientes             |
+| `/pacientes/novo`       | Formulário de cadastro         |
+| `/pacientes/:id`        | Detalhes do paciente           |
+| `/pacientes/:id/editar` | Formulário de edição           |
 
-## Additional Resources
+---
 
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+## Proxy de desenvolvimento
+
+O Angular CLI redireciona `/api/*` → `http://localhost:8080/*` via `proxy.conf.json`, eliminando problemas de CORS em ambiente local.

--- a/docs/context.md
+++ b/docs/context.md
@@ -16,8 +16,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 2. Implementação do módulo de pacientes (listagem, formulário, detalhe)
 3. Adição da pasta `/docs` com documentação do projeto
 4. Correção de CORS via proxy do Angular CLI
+5. Implementação de testes unitários e atualização da documentação
 
-A funcionalidade central de **gestão de pacientes** está operacional. Ainda não há autenticação, outros módulos ou configuração de ambiente.
+A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. Ainda não há autenticação, outros módulos ou configuração de ambiente.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -246,6 +246,30 @@ npm test         # Execução dos testes unitários (Karma/Jasmine)
 
 ---
 
+## Testes Unitários
+
+Framework: **Karma + Jasmine**  
+Comando: `npm test`
+
+### Arquivos de teste
+
+| Arquivo | Cobertura |
+|---------|-----------|
+| `app/app.component.spec.ts` | Renderização da navbar e router-outlet |
+| `app/core/services/paciente.service.spec.ts` | Todos os métodos HTTP (listar, buscar, cadastrar, atualizar, inativar) |
+| `app/pages/pacientes/paciente-list/paciente-list.component.spec.ts` | Carregamento, paginação, inativação, estados de erro |
+| `app/pages/pacientes/paciente-form/paciente-form.component.spec.ts` | Modo criação e edição, validações, navegação, erros |
+| `app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts` | Carregamento, inativação, estados de erro |
+
+### Estratégia de mocking
+
+- **Serviço HTTP:** `HttpClientTestingModule` + `HttpTestingController` nos testes de serviço
+- **PacienteService nos componentes:** `jasmine.createSpyObj` com retorno via `of()` ou `throwError()`
+- **Router:** `RouterTestingModule` + `spyOn(router, 'navigate')`
+- **ActivatedRoute:** objeto literal com `snapshot.paramMap.get()`
+
+---
+
 ## Status do Projeto
 
 ### Implementado
@@ -255,12 +279,13 @@ npm test         # Execução dos testes unitários (Karma/Jasmine)
 - Feedback de erros e loading
 - Integração com API REST
 - Design responsivo
+- Testes unitários (serviço e todos os componentes de página)
 
 ### Não implementado / Próximos passos
 - Autenticação e autorização
 - Módulos adicionais: aulas, agendamentos, financeiro
-- Variável de ambiente para URL da API (atualmente hardcoded)
+- Variável de ambiente para URL da API (atualmente hardcoded via proxy)
 - Componente `ConfirmarDialog` integrado
-- Testes unitários e E2E completos
+- Testes E2E
 - Busca e filtros na listagem
 - Animações e transições

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,29 +1,37 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [AppComponent, RouterTestingModule],
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it(`should have the 'carlessopilatesfe' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('carlessopilatesfe');
-  });
-
-  it('should render title', () => {
+  it('should render the navbar', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, carlessopilatesfe');
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.navbar')).toBeTruthy();
+  });
+
+  it('should display "Carlesso Pilates" in the navbar brand', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.navbar-brand')?.textContent).toContain('Carlesso Pilates');
+  });
+
+  it('should contain a router-outlet', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/src/app/core/services/paciente.service.spec.ts
+++ b/src/app/core/services/paciente.service.spec.ts
@@ -1,0 +1,118 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PacienteService } from './paciente.service';
+import { Page, PacienteRequestDTO, PacienteResponseDTO, PacienteUpdateDTO } from '../models/paciente';
+
+const mockPaciente: PacienteResponseDTO = {
+  id: 1,
+  nome: 'Ana Silva',
+  email: 'ana@email.com',
+  cpf: '123.456.789-00',
+  telefone: '(11) 99999-9999',
+  dataNascimento: '1990-05-15',
+  endereco: null,
+  ativo: true
+};
+
+const mockPage: Page<PacienteResponseDTO> = {
+  content: [mockPaciente],
+  totalElements: 1,
+  totalPages: 1,
+  size: 10,
+  number: 0
+};
+
+describe('PacienteService', () => {
+  let service: PacienteService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PacienteService]
+    });
+    service = TestBed.inject(PacienteService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('listar', () => {
+    it('should GET /api/pacientes with default params (page=0, size=10, sort=nome)', () => {
+      service.listar().subscribe(page => {
+        expect(page.content).toEqual([mockPaciente]);
+        expect(page.totalPages).toBe(1);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/pacientes');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('page')).toBe('0');
+      expect(req.request.params.get('size')).toBe('10');
+      expect(req.request.params.get('sort')).toBe('nome');
+      req.flush(mockPage);
+    });
+
+    it('should pass custom page and size params', () => {
+      service.listar(2, 5).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/pacientes');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('size')).toBe('5');
+      req.flush({ ...mockPage, size: 5, number: 2 });
+    });
+  });
+
+  describe('buscar', () => {
+    it('should GET /api/pacientes/:id and return the patient', () => {
+      service.buscar(1).subscribe(p => expect(p).toEqual(mockPaciente));
+
+      const req = httpMock.expectOne('/api/pacientes/1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockPaciente);
+    });
+  });
+
+  describe('cadastrar', () => {
+    it('should POST to /api/pacientes with request body and return created patient', () => {
+      const dto: PacienteRequestDTO = {
+        nome: 'Ana Silva',
+        email: 'ana@email.com',
+        cpf: '123.456.789-00'
+      };
+
+      service.cadastrar(dto).subscribe(p => expect(p).toEqual(mockPaciente));
+
+      const req = httpMock.expectOne('/api/pacientes');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(mockPaciente);
+    });
+  });
+
+  describe('atualizar', () => {
+    it('should PUT to /api/pacientes/:id with request body and return updated patient', () => {
+      const dto: PacienteUpdateDTO = { nome: 'Ana Updated', telefone: '(11) 88888-8888' };
+
+      service.atualizar(1, dto).subscribe(p => expect(p).toEqual(mockPaciente));
+
+      const req = httpMock.expectOne('/api/pacientes/1');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(dto);
+      req.flush(mockPaciente);
+    });
+  });
+
+  describe('inativar', () => {
+    it('should DELETE /api/pacientes/:id', () => {
+      service.inativar(1).subscribe();
+
+      const req = httpMock.expectOne('/api/pacientes/1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+});

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PacienteDetailComponent } from './paciente-detail.component';
+import { PacienteService } from '../../../core/services/paciente.service';
+import { PacienteResponseDTO } from '../../../core/models/paciente';
+
+const mockPaciente: PacienteResponseDTO = {
+  id: 1,
+  nome: 'Ana Silva',
+  email: 'ana@email.com',
+  cpf: '123.456.789-00',
+  telefone: '(11) 99999-9999',
+  dataNascimento: '1990-05-15',
+  endereco: null,
+  ativo: true
+};
+
+describe('PacienteDetailComponent', () => {
+  let component: PacienteDetailComponent;
+  let fixture: ComponentFixture<PacienteDetailComponent>;
+  let serviceSpy: jasmine.SpyObj<PacienteService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'inativar']);
+    serviceSpy.buscar.and.returnValue(of(mockPaciente));
+
+    await TestBed.configureTestingModule({
+      imports: [PacienteDetailComponent, RouterTestingModule],
+      providers: [
+        { provide: PacienteService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    fixture = TestBed.createComponent(PacienteDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load patient by id on init', () => {
+    expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
+    expect(component.paciente).toEqual(mockPaciente);
+    expect(component.loading).toBeFalse();
+    expect(component.erro).toBeNull();
+  });
+
+  it('should set erro when buscar fails', () => {
+    serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+    component.ngOnInit();
+    expect(component.erro).toBe('Paciente não encontrado.');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should call inativar service and navigate to /pacientes on success', () => {
+    serviceSpy.inativar.and.returnValue(of(undefined));
+    component.inativar();
+    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+    expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
+  });
+
+  it('should set erro when inativar fails', () => {
+    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+    component.inativar();
+    expect(component.erro).toBe('Erro ao inativar paciente.');
+  });
+
+  it('should not call inativar service when paciente is null', () => {
+    component.paciente = null;
+    component.inativar();
+    expect(serviceSpy.inativar).not.toHaveBeenCalled();
+  });
+
+  it('should initialize confirmarInativar as false', () => {
+    expect(component.confirmarInativar).toBeFalse();
+  });
+});

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
@@ -1,0 +1,174 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PacienteFormComponent } from './paciente-form.component';
+import { PacienteService } from '../../../core/services/paciente.service';
+import { PacienteResponseDTO } from '../../../core/models/paciente';
+
+const mockPaciente: PacienteResponseDTO = {
+  id: 1,
+  nome: 'Ana Silva',
+  email: 'ana@email.com',
+  cpf: '123.456.789-00',
+  telefone: '(11) 99999-9999',
+  dataNascimento: '1990-05-15',
+  endereco: null,
+  ativo: true
+};
+
+describe('PacienteFormComponent', () => {
+  describe('in create mode (no id in route)', () => {
+    let component: PacienteFormComponent;
+    let fixture: ComponentFixture<PacienteFormComponent>;
+    let serviceSpy: jasmine.SpyObj<PacienteService>;
+    let router: Router;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('PacienteService', ['cadastrar', 'buscar', 'atualizar']);
+
+      await TestBed.configureTestingModule({
+        imports: [PacienteFormComponent, RouterTestingModule],
+        providers: [
+          { provide: PacienteService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => null } } } }
+        ]
+      }).compileComponents();
+
+      router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      fixture = TestBed.createComponent(PacienteFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create with isEdit false', () => {
+      expect(component).toBeTruthy();
+      expect(component.isEdit).toBeFalse();
+      expect(component.pacienteId).toBeNull();
+    });
+
+    it('should initialize all form controls', () => {
+      ['nome', 'email', 'cpf', 'telefone', 'dataNascimento', 'endereco'].forEach(ctrl => {
+        expect(component.form.contains(ctrl)).toBeTrue();
+      });
+    });
+
+    it('should have email and cpf enabled in create mode', () => {
+      expect(component.form.get('email')?.disabled).toBeFalse();
+      expect(component.form.get('cpf')?.disabled).toBeFalse();
+    });
+
+    it('should mark nome as invalid when fewer than 3 characters', () => {
+      component.form.get('nome')?.setValue('AB');
+      expect(component.form.get('nome')?.hasError('minlength')).toBeTrue();
+    });
+
+    it('should mark nome as invalid when empty', () => {
+      component.form.get('nome')?.setValue('');
+      expect(component.form.get('nome')?.hasError('required')).toBeTrue();
+    });
+
+    it('should mark email as invalid when malformed', () => {
+      component.form.get('email')?.setValue('not-an-email');
+      expect(component.form.get('email')?.hasError('email')).toBeTrue();
+    });
+
+    it('should call cadastrar and navigate to /pacientes on valid submit', () => {
+      serviceSpy.cadastrar.and.returnValue(of(mockPaciente));
+      component.form.patchValue({
+        nome: 'Ana Silva',
+        email: 'ana@email.com',
+        cpf: '123.456.789-00'
+      });
+      component.salvar();
+      expect(serviceSpy.cadastrar).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
+    });
+
+    it('should not call service when form is invalid', () => {
+      component.form.get('nome')?.setValue('');
+      component.salvar();
+      expect(serviceSpy.cadastrar).not.toHaveBeenCalled();
+    });
+
+    it('should set erro and clear salvando flag on cadastrar failure', () => {
+      serviceSpy.cadastrar.and.returnValue(throwError(() => new Error('fail')));
+      component.form.patchValue({ nome: 'Ana Silva', email: 'ana@email.com', cpf: '123' });
+      component.salvar();
+      expect(component.erro).toBe('Erro ao salvar paciente.');
+      expect(component.salvando).toBeFalse();
+    });
+
+    it('campo() should return the matching AbstractControl', () => {
+      expect(component.campo('nome')).toBe(component.form.get('nome'));
+    });
+  });
+
+  describe('in edit mode (id present in route)', () => {
+    let component: PacienteFormComponent;
+    let fixture: ComponentFixture<PacienteFormComponent>;
+    let serviceSpy: jasmine.SpyObj<PacienteService>;
+    let router: Router;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'cadastrar', 'atualizar']);
+      serviceSpy.buscar.and.returnValue(of(mockPaciente));
+
+      await TestBed.configureTestingModule({
+        imports: [PacienteFormComponent, RouterTestingModule],
+        providers: [
+          { provide: PacienteService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
+        ]
+      }).compileComponents();
+
+      router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      fixture = TestBed.createComponent(PacienteFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create with isEdit true and pacienteId set', () => {
+      expect(component.isEdit).toBeTrue();
+      expect(component.pacienteId).toBe(1);
+    });
+
+    it('should load patient data from service on init', () => {
+      expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
+      expect(component.form.get('nome')?.value).toBe('Ana Silva');
+    });
+
+    it('should disable email and cpf fields in edit mode', () => {
+      expect(component.form.get('email')?.disabled).toBeTrue();
+      expect(component.form.get('cpf')?.disabled).toBeTrue();
+    });
+
+    it('should call atualizar and navigate to /pacientes on valid submit', () => {
+      serviceSpy.atualizar.and.returnValue(of(mockPaciente));
+      component.salvar();
+      expect(serviceSpy.atualizar).toHaveBeenCalledWith(
+        1,
+        jasmine.objectContaining({ nome: 'Ana Silva' })
+      );
+      expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
+    });
+
+    it('should set erro and clear salvando flag on atualizar failure', () => {
+      serviceSpy.atualizar.and.returnValue(throwError(() => new Error('fail')));
+      component.salvar();
+      expect(component.erro).toBe('Erro ao salvar paciente.');
+      expect(component.salvando).toBeFalse();
+    });
+
+    it('should set erro when buscar fails on init', () => {
+      serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+      component.ngOnInit();
+      expect(component.erro).toBe('Erro ao carregar paciente.');
+      expect(component.loading).toBeFalse();
+    });
+  });
+});

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
@@ -1,0 +1,117 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+import { PacienteListComponent } from './paciente-list.component';
+import { PacienteService } from '../../../core/services/paciente.service';
+import { Page, PacienteResponseDTO } from '../../../core/models/paciente';
+
+const mockPaciente: PacienteResponseDTO = {
+  id: 1,
+  nome: 'Ana Silva',
+  email: 'ana@email.com',
+  cpf: '123.456.789-00',
+  telefone: '(11) 99999-9999',
+  dataNascimento: '1990-05-15',
+  endereco: null,
+  ativo: true
+};
+
+const mockPage: Page<PacienteResponseDTO> = {
+  content: [mockPaciente],
+  totalElements: 1,
+  totalPages: 3,
+  size: 10,
+  number: 0
+};
+
+describe('PacienteListComponent', () => {
+  let component: PacienteListComponent;
+  let fixture: ComponentFixture<PacienteListComponent>;
+  let serviceSpy: jasmine.SpyObj<PacienteService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PacienteService', ['listar', 'inativar']);
+    serviceSpy.listar.and.returnValue(of(mockPage));
+
+    await TestBed.configureTestingModule({
+      imports: [PacienteListComponent, RouterTestingModule],
+      providers: [{ provide: PacienteService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PacienteListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call listar on init with default page and size', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(0, 10);
+  });
+
+  it('should populate pacientes and totalPages on success', () => {
+    expect(component.pacientes).toEqual([mockPaciente]);
+    expect(component.totalPages).toBe(3);
+    expect(component.loading).toBeFalse();
+    expect(component.erro).toBeNull();
+  });
+
+  it('should set erro when listar fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregar();
+    expect(component.erro).toBe('Erro ao carregar pacientes. Verifique se a API está em execução.');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should set confirmarInativarId when confirmarInativar is called', () => {
+    component.confirmarInativar(5);
+    expect(component.confirmarInativarId).toBe(5);
+  });
+
+  it('should clear confirmarInativarId when cancelarInativar is called', () => {
+    component.confirmarInativarId = 5;
+    component.cancelarInativar();
+    expect(component.confirmarInativarId).toBeNull();
+  });
+
+  it('should not call service.inativar when confirmarInativarId is null', () => {
+    component.confirmarInativarId = null;
+    component.inativar();
+    expect(serviceSpy.inativar).not.toHaveBeenCalled();
+  });
+
+  it('should call inativar, clear id, and reload list on success', () => {
+    serviceSpy.inativar.and.returnValue(of(undefined));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+    expect(component.confirmarInativarId).toBeNull();
+    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set erro and clear id when inativar fails', () => {
+    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(component.erro).toBe('Erro ao inativar paciente.');
+    expect(component.confirmarInativarId).toBeNull();
+  });
+
+  it('should change currentPage and reload when pagina is called', () => {
+    component.pagina(2);
+    expect(component.currentPage).toBe(2);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(2, 10);
+  });
+
+  it('should return array of page indices from pages()', () => {
+    component.totalPages = 3;
+    expect(component.pages()).toEqual([0, 1, 2]);
+  });
+
+  it('should return empty array from pages() when totalPages is 0', () => {
+    component.totalPages = 0;
+    expect(component.pages()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumo

- Implementa testes unitários para o serviço e todos os componentes de página
- Corrige o `app.component.spec.ts` gerado pelo Angular CLI (testes estavam desatualizados)
- Atualiza `README.md` com documentação específica do projeto (substituindo o template genérico do Angular CLI)
- Atualiza `docs/documentacao.md` com seção de testes e estratégia de mocking
- Atualiza `docs/context.md` com o estado atual do projeto

## Testes adicionados

| Arquivo | Cenários cobertos |
|---------|-------------------|
| `app.component.spec.ts` | Criação, navbar, router-outlet |
| `paciente.service.spec.ts` | `listar`, `buscar`, `cadastrar`, `atualizar`, `inativar` com `HttpTestingController` |
| `paciente-list.component.spec.ts` | Carregamento, paginação, confirmação e inativação, estados de erro |
| `paciente-form.component.spec.ts` | Modo criação e edição, validações (minlength, email, required), navegação, erros |
| `paciente-detail.component.spec.ts` | Carregamento, inativação, guard quando `paciente` é null, estados de erro |

## Plano de testes

- [ ] Executar `npm test` e confirmar que todos os specs passam
- [ ] Verificar cobertura dos cenários de erro (service down, 404, etc.)
- [ ] Revisar mocks do `ActivatedRoute` e `Router`

https://claude.ai/code/session_01LM5pasWh4astegpoUBgtBt