### PR TITLE
feat: alinha frontend com API v2 (ativar/inativar PATCH, email mutável)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ Arquivos de teste:
 
 ## Rotas
 
-| Caminho                 | Função                         |
-|-------------------------|--------------------------------|
-| `/`                     | Redireciona para `/pacientes`  |
-| `/pacientes`            | Lista de pacientes             |
-| `/pacientes/novo`       | Formulário de cadastro         |
-| `/pacientes/:id`        | Detalhes do paciente           |
-| `/pacientes/:id/editar` | Formulário de edição           |
+| Caminho                 | Função                                      |
+|-------------------------|---------------------------------------------|
+| `/`                     | Redireciona para `/pacientes`               |
+| `/pacientes`            | Lista de pacientes ativos (paginada)        |
+| `/pacientes/novo`       | Formulário de cadastro                      |
+| `/pacientes/:id`        | Detalhes do paciente (ativo ou inativo)     |
+| `/pacientes/:id/editar` | Formulário de edição                        |
+
+Na tela de detalhe, o botão de ação muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos.
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -17,6 +17,7 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 3. Adição da pasta `/docs` com documentação do projeto
 4. Correção de CORS via proxy do Angular CLI
 5. Implementação de testes unitários e atualização da documentação
+6. Alinhamento com API v2: PATCH ativar/inativar, e-mail mutável no PUT
 
 A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. Ainda não há autenticação, outros módulos ou configuração de ambiente.
 
@@ -33,11 +34,11 @@ Cada componente de página é carregado sob demanda via `loadComponent()`, otimi
 ### Reactive Forms
 Formulários construídos com `FormBuilder` e `FormGroup` para controle granular de validação e estado.
 
-### Soft Delete (Inativação)
-O backend não remove pacientes fisicamente. A operação de "exclusão" chama `DELETE /pacientes/{id}` que inativa o registro. A listagem exibe apenas pacientes ativos.
+### Soft Delete (Inativação e Reativação)
+O backend não remove pacientes fisicamente. Inativação usa `PATCH /pacientes/{id}/inativar` e reativação usa `PATCH /pacientes/{id}/ativar`. A listagem exibe apenas pacientes ativos; o detalhe exibe qualquer status e oferece o botão correto (Ativar ou Inativar) conforme o estado atual do paciente.
 
-### E-mail e CPF imutáveis após cadastro
-Por regra de negócio, e-mail e CPF não podem ser alterados após a criação do paciente. O formulário de edição desabilita esses campos e usa `PacienteUpdateDTO` (sem esses campos) no PUT.
+### CPF imutável após cadastro
+Por regra de negócio, o CPF não pode ser alterado após o cadastro. O formulário de edição desabilita apenas o campo CPF. O e-mail pode ser atualizado via `PUT /pacientes/{id}` e é incluído no `PacienteUpdateDTO`.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -104,10 +104,11 @@ interface PacienteRequestDTO {
 ```
 
 ### `PacienteUpdateDTO`
-Payload para atualização (email e CPF são imutáveis).
+Payload para atualização (somente CPF é imutável; e-mail pode ser alterado).
 ```typescript
 interface PacienteUpdateDTO {
   nome?: string;
+  email?: string;
   telefone?: string;
   dataNascimento?: string;
   endereco?: EnderecoDTO;
@@ -138,11 +139,12 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 
 | Método            | Endpoint HTTP               | Descrição                        |
 |-------------------|-----------------------------|----------------------------------|
-| `listar(page, size)` | `GET /pacientes?page&size&sort=nome` | Lista pacientes paginados  |
+| `listar(page, size)` | `GET /pacientes?page&size&sort=nome` | Lista pacientes ativos paginados |
 | `buscar(id)`      | `GET /pacientes/{id}`       | Busca paciente por ID            |
 | `cadastrar(dto)`  | `POST /pacientes`           | Cria novo paciente               |
-| `atualizar(id, dto)` | `PUT /pacientes/{id}`    | Atualiza dados do paciente       |
-| `inativar(id)`    | `DELETE /pacientes/{id}`    | Inativa paciente (soft delete)   |
+| `atualizar(id, dto)` | `PUT /pacientes/{id}`    | Atualiza dados do paciente (e-mail incluso, CPF é imutável) |
+| `ativar(id)`      | `PATCH /pacientes/{id}/ativar` | Reativa paciente inativo      |
+| `inativar(id)`    | `PATCH /pacientes/{id}/inativar` | Inativa paciente (soft delete) |
 
 ---
 
@@ -178,14 +180,14 @@ Todos os componentes são carregados com **lazy loading** via `loadComponent()`.
 - Modo duplo: cadastro e edição
 - Reactive Form com seções: Dados Pessoais e Endereço
 - Validações: campos obrigatórios, formato de e-mail, mínimo de 3 caracteres no nome
-- Em modo edição: e-mail e CPF desabilitados (read-only)
+- Em modo edição: apenas CPF é desabilitado (e-mail pode ser atualizado)
 - Feedback de erros em tempo real
 
 ### `PacienteDetailComponent`
 - Exibição completa dos dados do paciente
 - Badge de status: Ativo (verde) / Inativo (vermelho)
-- Ações: Editar, Inativar, Voltar
-- Diálogo de confirmação para inativação
+- Ações: Editar, Voltar; **Inativar** (se ativo) ou **Ativar** (se inativo)
+- Diálogos de confirmação para ativação e inativação
 
 ### `ConfirmarDialogComponent` _(shared)_
 - Componente gerado, ainda não integrado (diálogos implementados inline nos componentes)
@@ -277,8 +279,10 @@ Comando: `npm test`
 - Paginação server-side
 - Validação de formulários
 - Feedback de erros e loading
-- Integração com API REST
+- Integração com API REST (contratos alinhados com backend v2)
 - Design responsivo
+- Ativação e inativação de pacientes via PATCH
+- E-mail mutável na edição (somente CPF é imutável)
 - Testes unitários (serviço e todos os componentes de página)
 
 ### Não implementado / Próximos passos

--- a/src/app/core/models/paciente.ts
+++ b/src/app/core/models/paciente.ts
@@ -29,6 +29,7 @@ export interface PacienteRequestDTO {
 
 export interface PacienteUpdateDTO {
   nome?: string;
+  email?: string;
   telefone?: string;
   dataNascimento?: string;
   endereco?: EnderecoDTO;

--- a/src/app/core/services/paciente.service.spec.ts
+++ b/src/app/core/services/paciente.service.spec.ts
@@ -95,7 +95,7 @@ describe('PacienteService', () => {
 
   describe('atualizar', () => {
     it('should PUT to /api/pacientes/:id with request body and return updated patient', () => {
-      const dto: PacienteUpdateDTO = { nome: 'Ana Updated', telefone: '(11) 88888-8888' };
+      const dto: PacienteUpdateDTO = { nome: 'Ana Updated', email: 'nova@email.com' };
 
       service.atualizar(1, dto).subscribe(p => expect(p).toEqual(mockPaciente));
 
@@ -106,12 +106,22 @@ describe('PacienteService', () => {
     });
   });
 
+  describe('ativar', () => {
+    it('should PATCH /api/pacientes/:id/ativar', () => {
+      service.ativar(1).subscribe();
+
+      const req = httpMock.expectOne('/api/pacientes/1/ativar');
+      expect(req.request.method).toBe('PATCH');
+      req.flush(null);
+    });
+  });
+
   describe('inativar', () => {
-    it('should DELETE /api/pacientes/:id', () => {
+    it('should PATCH /api/pacientes/:id/inativar', () => {
       service.inativar(1).subscribe();
 
-      const req = httpMock.expectOne('/api/pacientes/1');
-      expect(req.request.method).toBe('DELETE');
+      const req = httpMock.expectOne('/api/pacientes/1/inativar');
+      expect(req.request.method).toBe('PATCH');
       req.flush(null);
     });
   });

--- a/src/app/core/services/paciente.service.ts
+++ b/src/app/core/services/paciente.service.ts
@@ -33,7 +33,11 @@ export class PacienteService {
     return this.http.put<PacienteResponseDTO>(`${this.apiUrl}/${id}`, dto);
   }
 
+  ativar(id: number): Observable<void> {
+    return this.http.patch<void>(`${this.apiUrl}/${id}/ativar`, {});
+  }
+
   inativar(id: number): Observable<void> {
-    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+    return this.http.patch<void>(`${this.apiUrl}/${id}/inativar`, {});
   }
 }

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
@@ -2,6 +2,7 @@
   <h1>{{ paciente.nome }}</h1>
   <div class="acoes">
     <a [routerLink]="['/pacientes', paciente.id, 'editar']" class="btn btn-secondary">Editar</a>
+    <button class="btn btn-secondary" (click)="confirmarAtivar = true" *ngIf="!paciente.ativo">Ativar</button>
     <button class="btn btn-danger" (click)="confirmarInativar = true" *ngIf="paciente.ativo">Inativar</button>
     <a routerLink="/pacientes" class="btn btn-outline">Voltar</a>
   </div>
@@ -62,6 +63,16 @@
       </div>
     </div>
   </section>
+</div>
+
+<div class="dialog-overlay" *ngIf="confirmarAtivar">
+  <div class="dialog">
+    <p>Confirma a reativação de <strong>{{ paciente?.nome }}</strong>?</p>
+    <div class="dialog-actions">
+      <button class="btn btn-secondary" (click)="ativar()">Confirmar</button>
+      <button class="btn btn-outline" (click)="confirmarAtivar = false">Cancelar</button>
+    </div>
+  </div>
 </div>
 
 <div class="dialog-overlay" *ngIf="confirmarInativar">

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
@@ -6,7 +6,7 @@ import { PacienteDetailComponent } from './paciente-detail.component';
 import { PacienteService } from '../../../core/services/paciente.service';
 import { PacienteResponseDTO } from '../../../core/models/paciente';
 
-const mockPaciente: PacienteResponseDTO = {
+const mockPacienteAtivo: PacienteResponseDTO = {
   id: 1,
   nome: 'Ana Silva',
   email: 'ana@email.com',
@@ -17,23 +17,25 @@ const mockPaciente: PacienteResponseDTO = {
   ativo: true
 };
 
+const mockPacienteInativo: PacienteResponseDTO = { ...mockPacienteAtivo, ativo: false };
+
 describe('PacienteDetailComponent', () => {
   let component: PacienteDetailComponent;
   let fixture: ComponentFixture<PacienteDetailComponent>;
   let serviceSpy: jasmine.SpyObj<PacienteService>;
   let router: Router;
 
-  beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'inativar']);
-    serviceSpy.buscar.and.returnValue(of(mockPaciente));
+  function setup(paciente: PacienteResponseDTO = mockPacienteAtivo) {
+    serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'ativar', 'inativar']);
+    serviceSpy.buscar.and.returnValue(of(paciente));
 
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [PacienteDetailComponent, RouterTestingModule],
       providers: [
         { provide: PacienteService, useValue: serviceSpy },
         { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
       ]
-    }).compileComponents();
+    });
 
     router = TestBed.inject(Router);
     spyOn(router, 'navigate');
@@ -41,46 +43,82 @@ describe('PacienteDetailComponent', () => {
     fixture = TestBed.createComponent(PacienteDetailComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  describe('with active patient', () => {
+    beforeEach(() => setup(mockPacienteAtivo));
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should load patient by id on init', () => {
+      expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
+      expect(component.paciente).toEqual(mockPacienteAtivo);
+      expect(component.loading).toBeFalse();
+      expect(component.erro).toBeNull();
+    });
+
+    it('should initialize confirmarInativar and confirmarAtivar as false', () => {
+      expect(component.confirmarInativar).toBeFalse();
+      expect(component.confirmarAtivar).toBeFalse();
+    });
+
+    it('should call inativar service and navigate to /pacientes on success', () => {
+      serviceSpy.inativar.and.returnValue(of(undefined));
+      component.inativar();
+      expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+      expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
+    });
+
+    it('should set erro when inativar fails', () => {
+      serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+      component.inativar();
+      expect(component.erro).toBe('Erro ao inativar paciente.');
+    });
+
+    it('should not call inativar service when paciente is null', () => {
+      component.paciente = null;
+      component.inativar();
+      expect(serviceSpy.inativar).not.toHaveBeenCalled();
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('with inactive patient', () => {
+    beforeEach(() => setup(mockPacienteInativo));
+
+    it('should load inactive patient', () => {
+      expect(component.paciente?.ativo).toBeFalse();
+    });
+
+    it('should call ativar service and navigate to /pacientes on success', () => {
+      serviceSpy.ativar.and.returnValue(of(undefined));
+      component.ativar();
+      expect(serviceSpy.ativar).toHaveBeenCalledWith(1);
+      expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
+    });
+
+    it('should set erro when ativar fails', () => {
+      serviceSpy.ativar.and.returnValue(throwError(() => new Error('fail')));
+      component.ativar();
+      expect(component.erro).toBe('Erro ao ativar paciente.');
+    });
+
+    it('should not call ativar service when paciente is null', () => {
+      component.paciente = null;
+      component.ativar();
+      expect(serviceSpy.ativar).not.toHaveBeenCalled();
+    });
   });
 
-  it('should load patient by id on init', () => {
-    expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
-    expect(component.paciente).toEqual(mockPaciente);
-    expect(component.loading).toBeFalse();
-    expect(component.erro).toBeNull();
-  });
+  describe('load error', () => {
+    beforeEach(() => setup(mockPacienteAtivo));
 
-  it('should set erro when buscar fails', () => {
-    serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
-    component.ngOnInit();
-    expect(component.erro).toBe('Paciente não encontrado.');
-    expect(component.loading).toBeFalse();
-  });
-
-  it('should call inativar service and navigate to /pacientes on success', () => {
-    serviceSpy.inativar.and.returnValue(of(undefined));
-    component.inativar();
-    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
-    expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
-  });
-
-  it('should set erro when inativar fails', () => {
-    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
-    component.inativar();
-    expect(component.erro).toBe('Erro ao inativar paciente.');
-  });
-
-  it('should not call inativar service when paciente is null', () => {
-    component.paciente = null;
-    component.inativar();
-    expect(serviceSpy.inativar).not.toHaveBeenCalled();
-  });
-
-  it('should initialize confirmarInativar as false', () => {
-    expect(component.confirmarInativar).toBeFalse();
+    it('should set erro when buscar fails', () => {
+      serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+      component.ngOnInit();
+      expect(component.erro).toBe('Paciente não encontrado.');
+      expect(component.loading).toBeFalse();
+    });
   });
 });

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.ts
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.ts
@@ -15,6 +15,7 @@ export class PacienteDetailComponent implements OnInit {
   loading = false;
   erro: string | null = null;
   confirmarInativar = false;
+  confirmarAtivar = false;
 
   constructor(
     private service: PacienteService,
@@ -35,6 +36,14 @@ export class PacienteDetailComponent implements OnInit {
         this.erro = 'Paciente não encontrado.';
         this.loading = false;
       }
+    });
+  }
+
+  ativar(): void {
+    if (!this.paciente) return;
+    this.service.ativar(this.paciente.id).subscribe({
+      next: () => this.router.navigate(['/pacientes']),
+      error: () => (this.erro = 'Erro ao ativar paciente.')
     });
   }
 

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
@@ -142,17 +142,20 @@ describe('PacienteFormComponent', () => {
       expect(component.form.get('nome')?.value).toBe('Ana Silva');
     });
 
-    it('should disable email and cpf fields in edit mode', () => {
-      expect(component.form.get('email')?.disabled).toBeTrue();
+    it('should keep email enabled in edit mode (email is mutable)', () => {
+      expect(component.form.get('email')?.disabled).toBeFalse();
+    });
+
+    it('should disable only cpf field in edit mode (cpf is immutable)', () => {
       expect(component.form.get('cpf')?.disabled).toBeTrue();
     });
 
-    it('should call atualizar and navigate to /pacientes on valid submit', () => {
+    it('should include email in atualizar payload', () => {
       serviceSpy.atualizar.and.returnValue(of(mockPaciente));
       component.salvar();
       expect(serviceSpy.atualizar).toHaveBeenCalledWith(
         1,
-        jasmine.objectContaining({ nome: 'Ana Silva' })
+        jasmine.objectContaining({ nome: 'Ana Silva', email: 'ana@email.com' })
       );
       expect(router.navigate).toHaveBeenCalledWith(['/pacientes']);
     });

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
@@ -50,7 +50,6 @@ export class PacienteFormComponent implements OnInit {
       this.service.buscar(this.pacienteId).subscribe({
         next: p => {
           this.form.patchValue(p);
-          this.form.get('email')?.disable();
           this.form.get('cpf')?.disable();
           this.loading = false;
         },
@@ -74,6 +73,7 @@ export class PacienteFormComponent implements OnInit {
     const obs = this.isEdit && this.pacienteId !== null
       ? this.service.atualizar(this.pacienteId, {
           nome: valor.nome,
+          email: valor.email,
           telefone: valor.telefone,
           dataNascimento: valor.dataNascimento,
           endereco: valor.endereco


### PR DESCRIPTION
## Resumo

Alinha o frontend com os novos contratos da API v2 do backend (Spring Boot).

### Mudanças na API backend identificadas

| Funcionalidade | Antes (v1) | Depois (v2) |
|---|---|---|
| Inativar paciente | `DELETE /pacientes/{id}` | `PATCH /pacientes/{id}/inativar` |
| Ativar paciente | não existia | `PATCH /pacientes/{id}/ativar` |
| Atualizar e-mail | não permitido | permitido via `PUT /pacientes/{id}` |

---

### Arquivos alterados

**Modelo**
- `paciente.ts` — adiciona `email?: string` a `PacienteUpdateDTO` (somente CPF é imutável)

**Serviço**
- `paciente.service.ts` — troca `DELETE` por `PATCH .../inativar`; adiciona método `ativar()` com `PATCH .../ativar`

**Formulário**
- `paciente-form.component.ts` — remove disable do campo email no modo edição; inclui `email` no payload do PUT

**Detalhe**
- `paciente-detail.component.ts` — adiciona método `ativar()` e flag `confirmarAtivar`
- `paciente-detail.component.html` — botão **Ativar** (visível para pacientes inativos) e diálogo de confirmação correspondente

**Testes**
- `paciente.service.spec.ts` — atualiza teste de `inativar` (agora espera PATCH); adiciona suite para `ativar`
- `paciente-form.component.spec.ts` — corrige expectativas: email habilitado no modo edição, email presente no payload do `atualizar`
- `paciente-detail.component.spec.ts` — refatorado com describe por status do paciente; adiciona cenários de `ativar`

**Docs**
- `README.md`, `docs/documentacao.md`, `docs/context.md` — atualizados para refletir os novos contratos

---

## Plano de testes

- [ ] Executar `npm test` e confirmar que todos os specs passam
- [ ] Verificar botão **Ativar** aparece na tela de detalhe de paciente inativo
- [ ] Verificar botão **Inativar** aparece na tela de detalhe de paciente ativo
- [ ] Confirmar que o campo e-mail está editável no formulário de edição
- [ ] Confirmar que CPF permanece desabilitado no formulário de edição

https://claude.ai/code/session_01LM5pasWh4astegpoUBgtBt