### PR TITLE
feat: implementa módulos de Planos, Pagamentos e Aulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Arquivos de teste:
 
 ---
 
+## Módulos implementados
+
+| Módulo | Descrição |
+|--------|-----------|
+| **Pacientes** | CRUD completo com ativação/inativação |
+| **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
+| **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
+| **Aulas** | Visualização das aulas geradas e confirmação de presença |
+
+---
+
 ## Rotas
 
 | Caminho                 | Função                                      |
@@ -94,7 +105,15 @@ Arquivos de teste:
 | `/pacientes/:id`        | Detalhes do paciente (ativo ou inativo)     |
 | `/pacientes/:id/editar` | Formulário de edição                        |
 
-Na tela de detalhe, o botão de ação muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos.
+Na tela de detalhe, o botão de ação muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
+
+| Caminho | Função |
+|---------|--------|
+| `/pacientes/:id/planos` | Lista de planos do paciente |
+| `/pacientes/:id/planos/novo` | Criar novo plano |
+| `/pacientes/:id/pagamentos` | Lista de pagamentos |
+| `/pacientes/:id/pagamentos/novo` | Registrar novo pagamento |
+| `/pacientes/:id/aulas` | Lista de aulas geradas |
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -18,6 +18,7 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 4. Correção de CORS via proxy do Angular CLI
 5. Implementação de testes unitários e atualização da documentação
 6. Alinhamento com API v2: PATCH ativar/inativar, e-mail mutável no PUT
+7. Implementação dos módulos de Planos, Pagamentos e Aulas
 
 A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. Ainda não há autenticação, outros módulos ou configuração de ambiente.
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -26,6 +26,17 @@
 
 ---
 
+## Módulos
+
+| Módulo | Rotas | Funcionalidades |
+|--------|-------|-----------------|
+| Pacientes | `/pacientes`, `/pacientes/:id`, `/pacientes/novo`, `/pacientes/:id/editar` | CRUD completo, ativar/inativar |
+| Planos | `/pacientes/:id/planos`, `/pacientes/:id/planos/novo` | Listar, criar (com seleção de dias e validação de frequência), inativar |
+| Pagamentos | `/pacientes/:id/pagamentos`, `/pacientes/:id/pagamentos/novo` | Listar, criar, confirmar pagamento |
+| Aulas | `/pacientes/:id/aulas` | Listar, confirmar presença |
+
+---
+
 ## Estrutura de Pastas
 
 ```
@@ -283,13 +294,16 @@ Comando: `npm test`
 - Design responsivo
 - Ativação e inativação de pacientes via PATCH
 - E-mail mutável na edição (somente CPF é imutável)
+- Módulo Planos: listagem, criação com seleção de dias e validação de frequência
+- Módulo Pagamentos: listagem, criação e confirmação de pagamento (PAGO)
+- Módulo Aulas: listagem e confirmação de presença
+- Navegação contextual na tela de detalhe do paciente (Planos / Pagamentos / Aulas)
 - Testes unitários (serviço e todos os componentes de página)
 
 ### Não implementado / Próximos passos
 - Autenticação e autorização
-- Módulos adicionais: aulas, agendamentos, financeiro
 - Variável de ambiente para URL da API (atualmente hardcoded via proxy)
 - Componente `ConfirmarDialog` integrado
 - Testes E2E
-- Busca e filtros na listagem
+- Busca e filtros nas listagens
 - Animações e transições

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,29 +5,46 @@ export const routes: Routes = [
   {
     path: 'pacientes',
     loadComponent: () =>
-      import('./pages/pacientes/paciente-list/paciente-list.component').then(
-        m => m.PacienteListComponent
-      )
+      import('./pages/pacientes/paciente-list/paciente-list.component').then(m => m.PacienteListComponent)
   },
   {
     path: 'pacientes/novo',
     loadComponent: () =>
-      import('./pages/pacientes/paciente-form/paciente-form.component').then(
-        m => m.PacienteFormComponent
-      )
-  },
-  {
-    path: 'pacientes/:id',
-    loadComponent: () =>
-      import('./pages/pacientes/paciente-detail/paciente-detail.component').then(
-        m => m.PacienteDetailComponent
-      )
+      import('./pages/pacientes/paciente-form/paciente-form.component').then(m => m.PacienteFormComponent)
   },
   {
     path: 'pacientes/:id/editar',
     loadComponent: () =>
-      import('./pages/pacientes/paciente-form/paciente-form.component').then(
-        m => m.PacienteFormComponent
-      )
+      import('./pages/pacientes/paciente-form/paciente-form.component').then(m => m.PacienteFormComponent)
+  },
+  {
+    path: 'pacientes/:id/planos/novo',
+    loadComponent: () =>
+      import('./pages/planos/plano-form/plano-form.component').then(m => m.PlanoFormComponent)
+  },
+  {
+    path: 'pacientes/:id/planos',
+    loadComponent: () =>
+      import('./pages/planos/plano-list/plano-list.component').then(m => m.PlanoListComponent)
+  },
+  {
+    path: 'pacientes/:id/pagamentos/novo',
+    loadComponent: () =>
+      import('./pages/pagamentos/pagamento-form/pagamento-form.component').then(m => m.PagamentoFormComponent)
+  },
+  {
+    path: 'pacientes/:id/pagamentos',
+    loadComponent: () =>
+      import('./pages/pagamentos/pagamento-list/pagamento-list.component').then(m => m.PagamentoListComponent)
+  },
+  {
+    path: 'pacientes/:id/aulas',
+    loadComponent: () =>
+      import('./pages/aulas/aula-list/aula-list.component').then(m => m.AulaListComponent)
+  },
+  {
+    path: 'pacientes/:id',
+    loadComponent: () =>
+      import('./pages/pacientes/paciente-detail/paciente-detail.component').then(m => m.PacienteDetailComponent)
   }
 ];

--- a/src/app/core/models/plano.ts
+++ b/src/app/core/models/plano.ts
@@ -1,0 +1,79 @@
+export type TipoPagamento = 'MENSAL' | 'TRIMESTRAL' | 'ANUAL';
+export type FrequenciaSemanal = 'UMA_VEZ' | 'DUAS_VEZES' | 'TRES_VEZES';
+export type DiaSemana = 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY';
+export type StatusPagamento = 'PENDENTE' | 'PAGO' | 'VENCIDO';
+
+export interface PlanoResponseDTO {
+  id: number;
+  pacienteId: number;
+  tipo: TipoPagamento;
+  valor: number;
+  frequenciaSemanal: FrequenciaSemanal;
+  dataInicio: string;
+  diasSemana: DiaSemana[];
+  ativo: boolean;
+}
+
+export interface PlanoRequestDTO {
+  tipo: TipoPagamento;
+  valor: number;
+  frequenciaSemanal: FrequenciaSemanal;
+  dataInicio: string;
+  diasSemana: DiaSemana[];
+}
+
+export interface PagamentoResponseDTO {
+  id: number;
+  pacienteId: number;
+  planoId: number;
+  valor: number;
+  status: StatusPagamento;
+  dataPagamento: string | null;
+  dataVencimento: string;
+  periodoInicio: string;
+  periodoFim: string;
+}
+
+export interface PagamentoRequestDTO {
+  planoId: number;
+  valor: number;
+  dataVencimento: string;
+  periodoInicio: string;
+  periodoFim: string;
+}
+
+export interface AulaResponseDTO {
+  id: number;
+  pacienteId: number;
+  pagamentoId: number;
+  data: string;
+  realizada: boolean;
+}
+
+export const DIAS_SEMANA_LABEL: Record<DiaSemana, string> = {
+  MONDAY: 'Segunda',
+  TUESDAY: 'Terça',
+  WEDNESDAY: 'Quarta',
+  THURSDAY: 'Quinta',
+  FRIDAY: 'Sexta',
+  SATURDAY: 'Sábado',
+  SUNDAY: 'Domingo'
+};
+
+export const TIPO_LABEL: Record<TipoPagamento, string> = {
+  MENSAL: 'Mensal',
+  TRIMESTRAL: 'Trimestral',
+  ANUAL: 'Anual'
+};
+
+export const FREQUENCIA_LABEL: Record<FrequenciaSemanal, string> = {
+  UMA_VEZ: '1x por semana',
+  DUAS_VEZES: '2x por semana',
+  TRES_VEZES: '3x por semana'
+};
+
+export const FREQUENCIA_DIAS: Record<FrequenciaSemanal, number> = {
+  UMA_VEZ: 1,
+  DUAS_VEZES: 2,
+  TRES_VEZES: 3
+};

--- a/src/app/core/services/aula.service.spec.ts
+++ b/src/app/core/services/aula.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AulaService } from './aula.service';
+import { AulaResponseDTO } from '../models/plano';
+
+const mockAula: AulaResponseDTO = {
+  id: 1,
+  pacienteId: 10,
+  pagamentoId: 1,
+  data: '2026-05-05',
+  realizada: false
+};
+
+describe('AulaService', () => {
+  let service: AulaService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AulaService]
+    });
+    service = TestBed.inject(AulaService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('listar', () => {
+    it('should GET /api/pacientes/:id/aulas', () => {
+      service.listar(10).subscribe(aulas => expect(aulas).toEqual([mockAula]));
+      const req = httpMock.expectOne('/api/pacientes/10/aulas');
+      expect(req.request.method).toBe('GET');
+      req.flush([mockAula]);
+    });
+  });
+
+  describe('confirmar', () => {
+    it('should PATCH /api/aulas/:id/confirmar', () => {
+      service.confirmar(1).subscribe();
+      const req = httpMock.expectOne('/api/aulas/1/confirmar');
+      expect(req.request.method).toBe('PATCH');
+      req.flush(null);
+    });
+  });
+});

--- a/src/app/core/services/aula.service.ts
+++ b/src/app/core/services/aula.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AulaResponseDTO } from '../models/plano';
+
+@Injectable({ providedIn: 'root' })
+export class AulaService {
+  private readonly apiUrl = '/api';
+
+  constructor(private http: HttpClient) {}
+
+  listar(pacienteId: number): Observable<AulaResponseDTO[]> {
+    return this.http.get<AulaResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/aulas`);
+  }
+
+  confirmar(aulaId: number): Observable<void> {
+    return this.http.patch<void>(`${this.apiUrl}/aulas/${aulaId}/confirmar`, {});
+  }
+}

--- a/src/app/core/services/pagamento.service.spec.ts
+++ b/src/app/core/services/pagamento.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PagamentoService } from './pagamento.service';
+import { PagamentoRequestDTO, PagamentoResponseDTO } from '../models/plano';
+
+const mockPagamento: PagamentoResponseDTO = {
+  id: 1,
+  pacienteId: 10,
+  planoId: 1,
+  valor: 250,
+  status: 'PENDENTE',
+  dataPagamento: null,
+  dataVencimento: '2026-05-10',
+  periodoInicio: '2026-05-01',
+  periodoFim: '2026-05-31'
+};
+
+describe('PagamentoService', () => {
+  let service: PagamentoService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PagamentoService]
+    });
+    service = TestBed.inject(PagamentoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('listar', () => {
+    it('should GET /api/pacientes/:id/pagamentos', () => {
+      service.listar(10).subscribe(p => expect(p).toEqual([mockPagamento]));
+      const req = httpMock.expectOne('/api/pacientes/10/pagamentos');
+      expect(req.request.method).toBe('GET');
+      req.flush([mockPagamento]);
+    });
+  });
+
+  describe('criar', () => {
+    it('should POST to /api/pagamentos with body', () => {
+      const dto: PagamentoRequestDTO = {
+        planoId: 1,
+        valor: 250,
+        dataVencimento: '2026-05-10',
+        periodoInicio: '2026-05-01',
+        periodoFim: '2026-05-31'
+      };
+      service.criar(dto).subscribe(p => expect(p).toEqual(mockPagamento));
+      const req = httpMock.expectOne('/api/pagamentos');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(mockPagamento);
+    });
+  });
+
+  describe('pagar', () => {
+    it('should PATCH /api/pagamentos/:id/pagar with dataPagamento', () => {
+      const pagoPagamento = { ...mockPagamento, status: 'PAGO' as const, dataPagamento: '2026-05-05' };
+      service.pagar(1, '2026-05-05').subscribe(p => expect(p.status).toBe('PAGO'));
+      const req = httpMock.expectOne('/api/pagamentos/1/pagar');
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ dataPagamento: '2026-05-05' });
+      req.flush(pagoPagamento);
+    });
+  });
+});

--- a/src/app/core/services/pagamento.service.ts
+++ b/src/app/core/services/pagamento.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PagamentoRequestDTO, PagamentoResponseDTO } from '../models/plano';
+
+@Injectable({ providedIn: 'root' })
+export class PagamentoService {
+  private readonly apiUrl = '/api';
+
+  constructor(private http: HttpClient) {}
+
+  listar(pacienteId: number): Observable<PagamentoResponseDTO[]> {
+    return this.http.get<PagamentoResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/pagamentos`);
+  }
+
+  criar(dto: PagamentoRequestDTO): Observable<PagamentoResponseDTO> {
+    return this.http.post<PagamentoResponseDTO>(`${this.apiUrl}/pagamentos`, dto);
+  }
+
+  pagar(pagamentoId: number, dataPagamento: string): Observable<PagamentoResponseDTO> {
+    return this.http.patch<PagamentoResponseDTO>(
+      `${this.apiUrl}/pagamentos/${pagamentoId}/pagar`,
+      { dataPagamento }
+    );
+  }
+}

--- a/src/app/core/services/plano.service.spec.ts
+++ b/src/app/core/services/plano.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PlanoService } from './plano.service';
+import { PlanoRequestDTO, PlanoResponseDTO } from '../models/plano';
+
+const mockPlano: PlanoResponseDTO = {
+  id: 1,
+  pacienteId: 10,
+  tipo: 'MENSAL',
+  valor: 250,
+  frequenciaSemanal: 'DUAS_VEZES',
+  dataInicio: '2026-05-01',
+  diasSemana: ['MONDAY', 'WEDNESDAY'],
+  ativo: true
+};
+
+describe('PlanoService', () => {
+  let service: PlanoService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PlanoService]
+    });
+    service = TestBed.inject(PlanoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('listar', () => {
+    it('should GET /api/pacientes/:id/planos', () => {
+      service.listar(10).subscribe(planos => expect(planos).toEqual([mockPlano]));
+      const req = httpMock.expectOne('/api/pacientes/10/planos');
+      expect(req.request.method).toBe('GET');
+      req.flush([mockPlano]);
+    });
+  });
+
+  describe('criar', () => {
+    it('should POST to /api/pacientes/:id/planos with body', () => {
+      const dto: PlanoRequestDTO = {
+        tipo: 'MENSAL',
+        valor: 250,
+        frequenciaSemanal: 'DUAS_VEZES',
+        dataInicio: '2026-05-01',
+        diasSemana: ['MONDAY', 'WEDNESDAY']
+      };
+      service.criar(10, dto).subscribe(p => expect(p).toEqual(mockPlano));
+      const req = httpMock.expectOne('/api/pacientes/10/planos');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(mockPlano);
+    });
+  });
+
+  describe('inativar', () => {
+    it('should PATCH /api/planos/:id/inativar', () => {
+      service.inativar(1).subscribe();
+      const req = httpMock.expectOne('/api/planos/1/inativar');
+      expect(req.request.method).toBe('PATCH');
+      req.flush(null);
+    });
+  });
+});

--- a/src/app/core/services/plano.service.ts
+++ b/src/app/core/services/plano.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PlanoRequestDTO, PlanoResponseDTO } from '../models/plano';
+
+@Injectable({ providedIn: 'root' })
+export class PlanoService {
+  private readonly apiUrl = '/api';
+
+  constructor(private http: HttpClient) {}
+
+  listar(pacienteId: number): Observable<PlanoResponseDTO[]> {
+    return this.http.get<PlanoResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/planos`);
+  }
+
+  criar(pacienteId: number, dto: PlanoRequestDTO): Observable<PlanoResponseDTO> {
+    return this.http.post<PlanoResponseDTO>(`${this.apiUrl}/pacientes/${pacienteId}/planos`, dto);
+  }
+
+  inativar(planoId: number): Observable<void> {
+    return this.http.patch<void>(`${this.apiUrl}/planos/${planoId}/inativar`, {});
+  }
+}

--- a/src/app/pages/aulas/aula-list/aula-list.component.html
+++ b/src/app/pages/aulas/aula-list/aula-list.component.html
@@ -1,0 +1,36 @@
+<div class="page-header">
+  <h1>Aulas do Paciente</h1>
+  <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<div *ngIf="!loading && aulas.length === 0 && !erro" class="empty-state">
+  Nenhuma aula gerada. As aulas são criadas automaticamente após a confirmação de um pagamento.
+</div>
+
+<table *ngIf="aulas.length > 0" class="table">
+  <thead>
+    <tr>
+      <th>Data</th>
+      <th>Status</th>
+      <th>Ações</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let aula of aulas">
+      <td>{{ aula.data | date:'dd/MM/yyyy (EEE)':'':'pt' }}</td>
+      <td>
+        <span class="badge" [class.badge-realizada]="aula.realizada" [class.badge-pendente]="!aula.realizada">
+          {{ aula.realizada ? 'Realizada' : 'Pendente' }}
+        </span>
+      </td>
+      <td>
+        <button class="btn btn-secondary btn-sm" *ngIf="!aula.realizada" (click)="confirmar(aula.id)">
+          Confirmar Presença
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/pages/aulas/aula-list/aula-list.component.scss
+++ b/src/app/pages/aulas/aula-list/aula-list.component.scss
@@ -1,0 +1,5 @@
+.badge { padding: 2px 10px; border-radius: var(--radius); font-size: 0.85rem; font-weight: 600; }
+.badge-realizada { background: #e8f5e9; color: var(--secondary); }
+.badge-pendente { background: #f5f5f5; color: var(--text-light); }
+.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
+.empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AulaListComponent } from './aula-list.component';
+import { AulaService } from '../../../core/services/aula.service';
+import { AulaResponseDTO } from '../../../core/models/plano';
+
+const mockAula: AulaResponseDTO = {
+  id: 1, pacienteId: 10, pagamentoId: 1, data: '2026-05-05', realizada: false
+};
+
+describe('AulaListComponent', () => {
+  let component: AulaListComponent;
+  let fixture: ComponentFixture<AulaListComponent>;
+  let serviceSpy: jasmine.SpyObj<AulaService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('AulaService', ['listar', 'confirmar']);
+    serviceSpy.listar.and.returnValue(of([mockAula]));
+
+    await TestBed.configureTestingModule({
+      imports: [AulaListComponent, RouterTestingModule],
+      providers: [
+        { provide: AulaService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AulaListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => expect(component).toBeTruthy());
+
+  it('should load aulas on init', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(10);
+    expect(component.aulas).toEqual([mockAula]);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should set erro when listar fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregar();
+    expect(component.erro).toBe('Erro ao carregar aulas.');
+  });
+
+  it('should call confirmar and reload on success', () => {
+    serviceSpy.confirmar.and.returnValue(of(undefined));
+    component.confirmar(1);
+    expect(serviceSpy.confirmar).toHaveBeenCalledWith(1);
+    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set erro when confirmar fails', () => {
+    serviceSpy.confirmar.and.returnValue(throwError(() => new Error('fail')));
+    component.confirmar(1);
+    expect(component.erro).toBe('Erro ao confirmar presença.');
+  });
+});

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { AulaService } from '../../../core/services/aula.service';
+import { AulaResponseDTO } from '../../../core/models/plano';
+
+@Component({
+  selector: 'app-aula-list',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './aula-list.component.html',
+  styleUrl: './aula-list.component.scss'
+})
+export class AulaListComponent implements OnInit {
+  pacienteId!: number;
+  aulas: AulaResponseDTO[] = [];
+  loading = false;
+  erro: string | null = null;
+
+  constructor(private service: AulaService, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading = true;
+    this.erro = null;
+    this.service.listar(this.pacienteId).subscribe({
+      next: aulas => {
+        this.aulas = aulas;
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar aulas.';
+        this.loading = false;
+      }
+    });
+  }
+
+  confirmar(id: number): void {
+    this.service.confirmar(id).subscribe({
+      next: () => this.carregar(),
+      error: () => (this.erro = 'Erro ao confirmar presença.')
+    });
+  }
+}

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
@@ -63,6 +63,24 @@
       </div>
     </div>
   </section>
+
+  <section class="detail-section links-section">
+    <h2>Gestão</h2>
+    <div class="links-grid">
+      <a [routerLink]="['/pacientes', paciente.id, 'planos']" class="link-card">
+        <span class="link-icon">📋</span>
+        <span>Planos</span>
+      </a>
+      <a [routerLink]="['/pacientes', paciente.id, 'pagamentos']" class="link-card">
+        <span class="link-icon">💳</span>
+        <span>Pagamentos</span>
+      </a>
+      <a [routerLink]="['/pacientes', paciente.id, 'aulas']" class="link-card">
+        <span class="link-icon">🗓</span>
+        <span>Aulas</span>
+      </a>
+    </div>
+  </section>
 </div>
 
 <div class="dialog-overlay" *ngIf="confirmarAtivar">

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.scss
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.scss
@@ -1,0 +1,30 @@
+.links-section { margin-top: 1.5rem; }
+
+.links-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.link-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 28px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 600;
+  transition: all 0.15s;
+
+  .link-icon { font-size: 1.5rem; }
+
+  &:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+    background: #f3f2ff;
+  }
+}

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.html
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.html
@@ -1,0 +1,60 @@
+<div class="page-header">
+  <h1>Novo Pagamento</h1>
+  <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-outline">Voltar</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="carregando" class="loading">Carregando planos...</div>
+
+<div *ngIf="!carregando && planos.length === 0 && !erro" class="alert alert-warning">
+  Este paciente não possui planos ativos. <a [routerLink]="['/pacientes', pacienteId, 'planos', 'novo']">Criar um plano</a>.
+</div>
+
+<form *ngIf="!carregando && planos.length > 0" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
+  <h2 class="form-section-title">Dados do Pagamento</h2>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="planoId">Plano *</label>
+      <select id="planoId" formControlName="planoId" class="form-control"
+        [class.is-invalid]="campo('planoId')?.invalid && campo('planoId')?.touched">
+        <option [value]="null">Selecione...</option>
+        <option *ngFor="let plano of planos" [value]="plano.id">
+          {{ tipoLabel[plano.tipo] }} — {{ plano.valor | currency:'BRL' }}
+        </option>
+      </select>
+      <div class="invalid-feedback" *ngIf="campo('planoId')?.invalid && campo('planoId')?.touched">Plano é obrigatório.</div>
+    </div>
+    <div class="form-group">
+      <label for="valor">Valor (R$) *</label>
+      <input id="valor" formControlName="valor" type="number" min="0" step="0.01" class="form-control"
+        [class.is-invalid]="campo('valor')?.invalid && campo('valor')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('valor')?.invalid && campo('valor')?.touched">Valor inválido.</div>
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="periodoInicio">Início do Período *</label>
+      <input id="periodoInicio" formControlName="periodoInicio" type="date" class="form-control"
+        [class.is-invalid]="campo('periodoInicio')?.invalid && campo('periodoInicio')?.touched" />
+    </div>
+    <div class="form-group">
+      <label for="periodoFim">Fim do Período *</label>
+      <input id="periodoFim" formControlName="periodoFim" type="date" class="form-control"
+        [class.is-invalid]="campo('periodoFim')?.invalid && campo('periodoFim')?.touched" />
+    </div>
+    <div class="form-group">
+      <label for="dataVencimento">Vencimento *</label>
+      <input id="dataVencimento" formControlName="dataVencimento" type="date" class="form-control"
+        [class.is-invalid]="campo('dataVencimento')?.invalid && campo('dataVencimento')?.touched" />
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button type="submit" class="btn btn-primary" [disabled]="salvando">
+      {{ salvando ? 'Salvando...' : 'Salvar' }}
+    </button>
+    <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-outline">Cancelar</a>
+  </div>
+</form>

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.scss
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.scss
@@ -1,0 +1,2 @@
+.alert-warning { background: #fff8e1; border: 1px solid #f57f17; color: #f57f17; padding: 12px; border-radius: var(--radius); }
+.alert-warning a { color: var(--primary); }

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { PagamentoService } from '../../../core/services/pagamento.service';
+import { PlanoService } from '../../../core/services/plano.service';
+import { PlanoResponseDTO, TIPO_LABEL } from '../../../core/models/plano';
+
+@Component({
+  selector: 'app-pagamento-form',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './pagamento-form.component.html',
+  styleUrl: './pagamento-form.component.scss'
+})
+export class PagamentoFormComponent implements OnInit {
+  form!: FormGroup;
+  pacienteId!: number;
+  planos: PlanoResponseDTO[] = [];
+  salvando = false;
+  carregando = false;
+  erro: string | null = null;
+
+  readonly tipoLabel = TIPO_LABEL;
+
+  constructor(
+    private fb: FormBuilder,
+    private pagamentoService: PagamentoService,
+    private planoService: PlanoService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.form = this.fb.group({
+      planoId: [null, Validators.required],
+      valor: [null, [Validators.required, Validators.min(0.01)]],
+      dataVencimento: ['', Validators.required],
+      periodoInicio: ['', Validators.required],
+      periodoFim: ['', Validators.required]
+    });
+    this.carregarPlanos();
+  }
+
+  carregarPlanos(): void {
+    this.carregando = true;
+    this.planoService.listar(this.pacienteId).subscribe({
+      next: planos => {
+        this.planos = planos.filter(p => p.ativo);
+        this.carregando = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar planos.';
+        this.carregando = false;
+      }
+    });
+  }
+
+  campo(nome: string) {
+    return this.form.get(nome);
+  }
+
+  salvar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.salvando = true;
+    this.erro = null;
+    this.pagamentoService.criar({ ...this.form.value, planoId: +this.form.value.planoId }).subscribe({
+      next: () => this.router.navigate(['/pacientes', this.pacienteId, 'pagamentos']),
+      error: () => {
+        this.erro = 'Erro ao registrar pagamento.';
+        this.salvando = false;
+      }
+    });
+  }
+}

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
@@ -1,0 +1,61 @@
+<div class="page-header">
+  <h1>Pagamentos do Paciente</h1>
+  <div class="acoes">
+    <a [routerLink]="['/pacientes', pacienteId, 'pagamentos', 'novo']" class="btn btn-primary">Novo Pagamento</a>
+    <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
+  </div>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<div *ngIf="!loading && pagamentos.length === 0 && !erro" class="empty-state">
+  Nenhum pagamento registrado.
+</div>
+
+<table *ngIf="pagamentos.length > 0" class="table">
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>Valor</th>
+      <th>Período</th>
+      <th>Vencimento</th>
+      <th>Pago em</th>
+      <th>Ações</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let p of pagamentos">
+      <td>
+        <span class="badge" [ngClass]="'badge-' + p.status.toLowerCase()">
+          {{ statusLabel[p.status] }}
+        </span>
+      </td>
+      <td>{{ p.valor | currency:'BRL' }}</td>
+      <td>{{ p.periodoInicio | date:'dd/MM/yyyy' }} – {{ p.periodoFim | date:'dd/MM/yyyy' }}</td>
+      <td>{{ p.dataVencimento | date:'dd/MM/yyyy' }}</td>
+      <td>{{ p.dataPagamento ? (p.dataPagamento | date:'dd/MM/yyyy') : '-' }}</td>
+      <td>
+        <button class="btn btn-secondary btn-sm" *ngIf="p.status === 'PENDENTE'" (click)="abrirPagar(p.id)">
+          Confirmar Pagamento
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="dialog-overlay" *ngIf="pagarId !== null">
+  <div class="dialog">
+    <h3>Confirmar Pagamento</h3>
+    <form [formGroup]="pagarForm">
+      <div class="form-group">
+        <label for="dataPagamento">Data do Pagamento *</label>
+        <input id="dataPagamento" formControlName="dataPagamento" type="date" class="form-control" />
+      </div>
+    </form>
+    <div class="dialog-actions">
+      <button class="btn btn-primary" (click)="confirmarPagar()" [disabled]="pagarForm.invalid">Confirmar</button>
+      <button class="btn btn-outline" (click)="cancelarPagar()">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
@@ -1,0 +1,6 @@
+.badge { padding: 2px 10px; border-radius: var(--radius); font-size: 0.85rem; font-weight: 600; }
+.badge-pendente { background: #fff8e1; color: #f57f17; }
+.badge-pago { background: #e8f5e9; color: var(--secondary); }
+.badge-vencido { background: #fce4ec; color: var(--danger); }
+.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
+.empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PagamentoListComponent } from './pagamento-list.component';
+import { PagamentoService } from '../../../core/services/pagamento.service';
+import { PagamentoResponseDTO } from '../../../core/models/plano';
+
+const mockPagamento: PagamentoResponseDTO = {
+  id: 1, pacienteId: 10, planoId: 1, valor: 250, status: 'PENDENTE',
+  dataPagamento: null, dataVencimento: '2026-05-10',
+  periodoInicio: '2026-05-01', periodoFim: '2026-05-31'
+};
+
+describe('PagamentoListComponent', () => {
+  let component: PagamentoListComponent;
+  let fixture: ComponentFixture<PagamentoListComponent>;
+  let serviceSpy: jasmine.SpyObj<PagamentoService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PagamentoService', ['listar', 'pagar']);
+    serviceSpy.listar.and.returnValue(of([mockPagamento]));
+
+    await TestBed.configureTestingModule({
+      imports: [PagamentoListComponent, RouterTestingModule],
+      providers: [
+        { provide: PagamentoService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PagamentoListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => expect(component).toBeTruthy());
+
+  it('should load pagamentos on init', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(10);
+    expect(component.pagamentos).toEqual([mockPagamento]);
+  });
+
+  it('should set erro when listar fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregar();
+    expect(component.erro).toBe('Erro ao carregar pagamentos.');
+  });
+
+  it('abrirPagar should set pagarId and reset form', () => {
+    component.abrirPagar(1);
+    expect(component.pagarId).toBe(1);
+    expect(component.pagarForm.value.dataPagamento).toBeFalsy();
+  });
+
+  it('cancelarPagar should clear pagarId', () => {
+    component.pagarId = 1;
+    component.cancelarPagar();
+    expect(component.pagarId).toBeNull();
+  });
+
+  it('should not call pagar when form is invalid', () => {
+    component.pagarId = 1;
+    component.confirmarPagar();
+    expect(serviceSpy.pagar).not.toHaveBeenCalled();
+  });
+
+  it('should call pagar and reload on success', () => {
+    const pago = { ...mockPagamento, status: 'PAGO' as const, dataPagamento: '2026-05-05' };
+    serviceSpy.pagar.and.returnValue(of(pago));
+    component.pagarId = 1;
+    component.pagarForm.setValue({ dataPagamento: '2026-05-05' });
+    component.confirmarPagar();
+    expect(serviceSpy.pagar).toHaveBeenCalledWith(1, '2026-05-05');
+    expect(component.pagarId).toBeNull();
+    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set erro when pagar fails', () => {
+    serviceSpy.pagar.and.returnValue(throwError(() => new Error('fail')));
+    component.pagarId = 1;
+    component.pagarForm.setValue({ dataPagamento: '2026-05-05' });
+    component.confirmarPagar();
+    expect(component.erro).toBe('Erro ao confirmar pagamento.');
+  });
+});

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { PagamentoService } from '../../../core/services/pagamento.service';
+import { PagamentoResponseDTO, StatusPagamento } from '../../../core/models/plano';
+
+@Component({
+  selector: 'app-pagamento-list',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './pagamento-list.component.html',
+  styleUrl: './pagamento-list.component.scss'
+})
+export class PagamentoListComponent implements OnInit {
+  pacienteId!: number;
+  pagamentos: PagamentoResponseDTO[] = [];
+  loading = false;
+  erro: string | null = null;
+  pagarId: number | null = null;
+  pagarForm!: FormGroup;
+
+  readonly statusLabel: Record<StatusPagamento, string> = {
+    PENDENTE: 'Pendente',
+    PAGO: 'Pago',
+    VENCIDO: 'Vencido'
+  };
+
+  constructor(
+    private service: PagamentoService,
+    private route: ActivatedRoute,
+    private fb: FormBuilder
+  ) {}
+
+  ngOnInit(): void {
+    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.pagarForm = this.fb.group({ dataPagamento: ['', Validators.required] });
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading = true;
+    this.erro = null;
+    this.service.listar(this.pacienteId).subscribe({
+      next: pagamentos => {
+        this.pagamentos = pagamentos;
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar pagamentos.';
+        this.loading = false;
+      }
+    });
+  }
+
+  abrirPagar(id: number): void {
+    this.pagarId = id;
+    this.pagarForm.reset();
+  }
+
+  cancelarPagar(): void {
+    this.pagarId = null;
+  }
+
+  confirmarPagar(): void {
+    if (this.pagarForm.invalid || this.pagarId === null) return;
+    const { dataPagamento } = this.pagarForm.value;
+    this.service.pagar(this.pagarId, dataPagamento).subscribe({
+      next: () => {
+        this.pagarId = null;
+        this.carregar();
+      },
+      error: () => {
+        this.erro = 'Erro ao confirmar pagamento.';
+        this.pagarId = null;
+      }
+    });
+  }
+}

--- a/src/app/pages/planos/plano-form/plano-form.component.html
+++ b/src/app/pages/planos/plano-form/plano-form.component.html
@@ -1,0 +1,72 @@
+<div class="page-header">
+  <h1>Novo Plano</h1>
+  <a [routerLink]="['/pacientes', pacienteId, 'planos']" class="btn btn-outline">Voltar</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+
+<form [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
+  <h2 class="form-section-title">Dados do Plano</h2>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="tipo">Tipo *</label>
+      <select id="tipo" formControlName="tipo" class="form-control"
+        [class.is-invalid]="campo('tipo')?.invalid && campo('tipo')?.touched">
+        <option value="">Selecione...</option>
+        <option *ngFor="let t of tipos" [value]="t">{{ tipoLabel[t] }}</option>
+      </select>
+      <div class="invalid-feedback" *ngIf="campo('tipo')?.invalid && campo('tipo')?.touched">Tipo é obrigatório.</div>
+    </div>
+    <div class="form-group">
+      <label for="valor">Valor (R$) *</label>
+      <input id="valor" formControlName="valor" type="number" min="0" step="0.01" class="form-control"
+        [class.is-invalid]="campo('valor')?.invalid && campo('valor')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('valor')?.invalid && campo('valor')?.touched">Valor inválido.</div>
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="frequenciaSemanal">Frequência *</label>
+      <select id="frequenciaSemanal" formControlName="frequenciaSemanal" class="form-control"
+        [class.is-invalid]="campo('frequenciaSemanal')?.invalid && campo('frequenciaSemanal')?.touched">
+        <option value="">Selecione...</option>
+        <option *ngFor="let f of frequencias" [value]="f">{{ frequenciaLabel[f] }}</option>
+      </select>
+      <div class="invalid-feedback" *ngIf="campo('frequenciaSemanal')?.invalid && campo('frequenciaSemanal')?.touched">Frequência é obrigatória.</div>
+    </div>
+    <div class="form-group">
+      <label for="dataInicio">Data de Início *</label>
+      <input id="dataInicio" formControlName="dataInicio" type="date" class="form-control"
+        [class.is-invalid]="campo('dataInicio')?.invalid && campo('dataInicio')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('dataInicio')?.invalid && campo('dataInicio')?.touched">Data é obrigatória.</div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label>Dias da Semana *
+      <span *ngIf="diasEsperados() > 0" class="hint">(selecione {{ diasEsperados() }} dia{{ diasEsperados() > 1 ? 's' : '' }})</span>
+    </label>
+    <div class="dias-grid">
+      <button type="button" *ngFor="let dia of diasDisponiveis"
+        class="dia-btn" [class.selected]="diaSelecionado(dia)"
+        (click)="toggleDia(dia)">
+        {{ diasLabel[dia] }}
+      </button>
+    </div>
+    <div class="invalid-feedback" *ngIf="campo('diasSemana')?.errors?.['diasInvalidos'] && campo('diasSemana')?.touched">
+      Selecione exatamente {{ campo('diasSemana')?.errors?.['diasInvalidos']?.esperado }} dia(s) para a frequência escolhida.
+    </div>
+    <div class="invalid-feedback" *ngIf="campo('diasSemana')?.errors?.['required'] && campo('diasSemana')?.touched">
+      Selecione ao menos um dia.
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button type="submit" class="btn btn-primary" [disabled]="salvando">
+      {{ salvando ? 'Salvando...' : 'Salvar' }}
+    </button>
+    <a [routerLink]="['/pacientes', pacienteId, 'planos']" class="btn btn-outline">Cancelar</a>
+  </div>
+</form>

--- a/src/app/pages/planos/plano-form/plano-form.component.scss
+++ b/src/app/pages/planos/plano-form/plano-form.component.scss
@@ -1,0 +1,29 @@
+.hint { font-size: 0.85rem; color: var(--text-light); margin-left: 6px; }
+
+.dias-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.dia-btn {
+  padding: 6px 14px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--white);
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: all 0.15s;
+
+  &.selected {
+    background: var(--primary);
+    color: var(--white);
+    border-color: var(--primary);
+  }
+
+  &:hover:not(.selected) {
+    border-color: var(--primary);
+    color: var(--primary);
+  }
+}

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -1,0 +1,104 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PlanoFormComponent } from './plano-form.component';
+import { PlanoService } from '../../../core/services/plano.service';
+import { PlanoResponseDTO } from '../../../core/models/plano';
+
+const mockPlano: PlanoResponseDTO = {
+  id: 1, pacienteId: 10, tipo: 'MENSAL', valor: 250,
+  frequenciaSemanal: 'DUAS_VEZES', dataInicio: '2026-05-01',
+  diasSemana: ['MONDAY', 'WEDNESDAY'], ativo: true
+};
+
+describe('PlanoFormComponent', () => {
+  let component: PlanoFormComponent;
+  let fixture: ComponentFixture<PlanoFormComponent>;
+  let serviceSpy: jasmine.SpyObj<PlanoService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PlanoService', ['criar']);
+
+    await TestBed.configureTestingModule({
+      imports: [PlanoFormComponent, RouterTestingModule],
+      providers: [
+        { provide: PlanoService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    fixture = TestBed.createComponent(PlanoFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => expect(component).toBeTruthy());
+
+  it('should initialize with pacienteId from route', () => {
+    expect(component.pacienteId).toBe(10);
+  });
+
+  it('should have all form controls', () => {
+    ['tipo', 'valor', 'frequenciaSemanal', 'dataInicio', 'diasSemana'].forEach(c =>
+      expect(component.form.contains(c)).toBeTrue()
+    );
+  });
+
+  it('should fail validation when diasSemana count does not match frequencia', () => {
+    component.form.patchValue({ frequenciaSemanal: 'DUAS_VEZES', diasSemana: ['MONDAY'] });
+    component.form.get('diasSemana')?.markAsTouched();
+    expect(component.form.get('diasSemana')?.hasError('diasInvalidos')).toBeTrue();
+  });
+
+  it('should pass validation when diasSemana matches frequencia', () => {
+    component.form.patchValue({ frequenciaSemanal: 'DUAS_VEZES', diasSemana: ['MONDAY', 'WEDNESDAY'] });
+    expect(component.form.get('diasSemana')?.hasError('diasInvalidos')).toBeFalse();
+  });
+
+  it('toggleDia should add and remove a day', () => {
+    component.toggleDia('MONDAY');
+    expect(component.diaSelecionado('MONDAY')).toBeTrue();
+    component.toggleDia('MONDAY');
+    expect(component.diaSelecionado('MONDAY')).toBeFalse();
+  });
+
+  it('diasEsperados should return correct count for frequencia', () => {
+    component.form.get('frequenciaSemanal')?.setValue('TRES_VEZES');
+    expect(component.diasEsperados()).toBe(3);
+  });
+
+  it('should call criar and navigate on valid submit', () => {
+    serviceSpy.criar.and.returnValue(of(mockPlano));
+    component.form.setValue({
+      tipo: 'MENSAL',
+      valor: 250,
+      frequenciaSemanal: 'DUAS_VEZES',
+      dataInicio: '2026-05-01',
+      diasSemana: ['MONDAY', 'WEDNESDAY']
+    });
+    component.salvar();
+    expect(serviceSpy.criar).toHaveBeenCalledWith(10, component.form.value);
+    expect(router.navigate).toHaveBeenCalledWith(['/pacientes', 10, 'planos']);
+  });
+
+  it('should set erro on criar failure', () => {
+    serviceSpy.criar.and.returnValue(throwError(() => new Error('fail')));
+    component.form.setValue({
+      tipo: 'MENSAL', valor: 250, frequenciaSemanal: 'UMA_VEZ',
+      dataInicio: '2026-05-01', diasSemana: ['MONDAY']
+    });
+    component.salvar();
+    expect(component.erro).toBe('Erro ao salvar plano.');
+    expect(component.salvando).toBeFalse();
+  });
+
+  it('should not call service when form is invalid', () => {
+    component.salvar();
+    expect(serviceSpy.criar).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/planos/plano-form/plano-form.component.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.ts
@@ -1,0 +1,90 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { PlanoService } from '../../../core/services/plano.service';
+import { DiaSemana, FREQUENCIA_DIAS, FrequenciaSemanal } from '../../../core/models/plano';
+
+function diasSemanaValidator(control: AbstractControl): ValidationErrors | null {
+  const group = control.parent;
+  if (!group) return null;
+  const frequencia: FrequenciaSemanal = group.get('frequenciaSemanal')?.value;
+  const dias: DiaSemana[] = group.get('diasSemana')?.value ?? [];
+  if (!frequencia || !dias.length) return null;
+  const esperado = FREQUENCIA_DIAS[frequencia];
+  return dias.length === esperado ? null : { diasInvalidos: { esperado, atual: dias.length } };
+}
+
+@Component({
+  selector: 'app-plano-form',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './plano-form.component.html',
+  styleUrl: './plano-form.component.scss'
+})
+export class PlanoFormComponent implements OnInit {
+  form!: FormGroup;
+  pacienteId!: number;
+  salvando = false;
+  erro: string | null = null;
+
+  readonly tipos = ['MENSAL', 'TRIMESTRAL', 'ANUAL'] as const;
+  readonly frequencias = ['UMA_VEZ', 'DUAS_VEZES', 'TRES_VEZES'] as const;
+  readonly diasDisponiveis: DiaSemana[] = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'];
+  readonly diasLabel: Record<DiaSemana, string> = {
+    MONDAY: 'Segunda', TUESDAY: 'Terça', WEDNESDAY: 'Quarta',
+    THURSDAY: 'Quinta', FRIDAY: 'Sexta', SATURDAY: 'Sábado', SUNDAY: 'Domingo'
+  };
+  readonly tipoLabel: Record<string, string> = { MENSAL: 'Mensal', TRIMESTRAL: 'Trimestral', ANUAL: 'Anual' };
+  readonly frequenciaLabel: Record<string, string> = { UMA_VEZ: '1x por semana', DUAS_VEZES: '2x por semana', TRES_VEZES: '3x por semana' };
+
+  constructor(private fb: FormBuilder, private service: PlanoService, private route: ActivatedRoute, private router: Router) {}
+
+  ngOnInit(): void {
+    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.form = this.fb.group({
+      tipo: ['', Validators.required],
+      valor: [null, [Validators.required, Validators.min(0.01)]],
+      frequenciaSemanal: ['', Validators.required],
+      dataInicio: ['', Validators.required],
+      diasSemana: [[], [Validators.required, diasSemanaValidator]]
+    });
+    this.form.get('frequenciaSemanal')?.valueChanges.subscribe(() => {
+      this.form.get('diasSemana')?.updateValueAndValidity();
+    });
+  }
+
+  toggleDia(dia: DiaSemana): void {
+    const atual: DiaSemana[] = this.form.get('diasSemana')!.value;
+    const novo = atual.includes(dia) ? atual.filter(d => d !== dia) : [...atual, dia];
+    this.form.get('diasSemana')!.setValue(novo);
+  }
+
+  diaSelecionado(dia: DiaSemana): boolean {
+    return (this.form.get('diasSemana')!.value as DiaSemana[]).includes(dia);
+  }
+
+  diasEsperados(): number {
+    const f: FrequenciaSemanal = this.form.get('frequenciaSemanal')?.value;
+    return f ? FREQUENCIA_DIAS[f] : 0;
+  }
+
+  campo(nome: string) {
+    return this.form.get(nome);
+  }
+
+  salvar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.salvando = true;
+    this.erro = null;
+    this.service.criar(this.pacienteId, this.form.value).subscribe({
+      next: () => this.router.navigate(['/pacientes', this.pacienteId, 'planos']),
+      error: () => {
+        this.erro = 'Erro ao salvar plano.';
+        this.salvando = false;
+      }
+    });
+  }
+}

--- a/src/app/pages/planos/plano-list/plano-list.component.html
+++ b/src/app/pages/planos/plano-list/plano-list.component.html
@@ -1,0 +1,56 @@
+<div class="page-header">
+  <h1>Planos do Paciente</h1>
+  <div class="acoes">
+    <a [routerLink]="['/pacientes', pacienteId, 'planos', 'novo']" class="btn btn-primary">Novo Plano</a>
+    <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
+  </div>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<div *ngIf="!loading && planos.length === 0 && !erro" class="empty-state">
+  Nenhum plano cadastrado.
+</div>
+
+<table *ngIf="planos.length > 0" class="table">
+  <thead>
+    <tr>
+      <th>Tipo</th>
+      <th>Valor</th>
+      <th>Frequência</th>
+      <th>Dias</th>
+      <th>Início</th>
+      <th>Status</th>
+      <th>Ações</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let plano of planos">
+      <td>{{ tipoLabel[plano.tipo] }}</td>
+      <td>{{ plano.valor | currency:'BRL' }}</td>
+      <td>{{ frequenciaLabel[plano.frequenciaSemanal] }}</td>
+      <td>{{ diasFormatados(plano) }}</td>
+      <td>{{ plano.dataInicio | date:'dd/MM/yyyy' }}</td>
+      <td>
+        <span class="badge" [class.badge-ativo]="plano.ativo" [class.badge-inativo]="!plano.ativo">
+          {{ plano.ativo ? 'Ativo' : 'Inativo' }}
+        </span>
+      </td>
+      <td class="acoes-col">
+        <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-secondary btn-sm">Pagamentos</a>
+        <button class="btn btn-danger btn-sm" *ngIf="plano.ativo" (click)="confirmarInativar(plano.id)">Inativar</button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="dialog-overlay" *ngIf="confirmarInativarId !== null">
+  <div class="dialog">
+    <p>Confirma a inativação deste plano?</p>
+    <div class="dialog-actions">
+      <button class="btn btn-danger" (click)="inativar()">Confirmar</button>
+      <button class="btn btn-outline" (click)="cancelarInativar()">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/planos/plano-list/plano-list.component.scss
+++ b/src/app/pages/planos/plano-list/plano-list.component.scss
@@ -1,0 +1,11 @@
+.badge {
+  padding: 2px 10px;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.badge-ativo { background: #e8f5e9; color: var(--secondary); }
+.badge-inativo { background: #fce4ec; color: var(--danger); }
+.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
+.acoes-col { display: flex; gap: 6px; }
+.empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }

--- a/src/app/pages/planos/plano-list/plano-list.component.spec.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PlanoListComponent } from './plano-list.component';
+import { PlanoService } from '../../../core/services/plano.service';
+import { PlanoResponseDTO } from '../../../core/models/plano';
+
+const mockPlano: PlanoResponseDTO = {
+  id: 1, pacienteId: 10, tipo: 'MENSAL', valor: 250,
+  frequenciaSemanal: 'DUAS_VEZES', dataInicio: '2026-05-01',
+  diasSemana: ['MONDAY', 'WEDNESDAY'], ativo: true
+};
+
+describe('PlanoListComponent', () => {
+  let component: PlanoListComponent;
+  let fixture: ComponentFixture<PlanoListComponent>;
+  let serviceSpy: jasmine.SpyObj<PlanoService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PlanoService', ['listar', 'inativar']);
+    serviceSpy.listar.and.returnValue(of([mockPlano]));
+
+    await TestBed.configureTestingModule({
+      imports: [PlanoListComponent, RouterTestingModule],
+      providers: [
+        { provide: PlanoService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlanoListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => expect(component).toBeTruthy());
+
+  it('should load planos on init', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(10);
+    expect(component.planos).toEqual([mockPlano]);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should set erro when listar fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregar();
+    expect(component.erro).toBe('Erro ao carregar planos.');
+  });
+
+  it('should set confirmarInativarId when confirmarInativar is called', () => {
+    component.confirmarInativar(1);
+    expect(component.confirmarInativarId).toBe(1);
+  });
+
+  it('should clear confirmarInativarId when cancelarInativar is called', () => {
+    component.confirmarInativarId = 1;
+    component.cancelarInativar();
+    expect(component.confirmarInativarId).toBeNull();
+  });
+
+  it('should call inativar service and reload on success', () => {
+    serviceSpy.inativar.and.returnValue(of(undefined));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+    expect(component.confirmarInativarId).toBeNull();
+    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set erro when inativar fails', () => {
+    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(component.erro).toBe('Erro ao inativar plano.');
+  });
+
+  it('diasFormatados should join day labels', () => {
+    const result = component.diasFormatados(mockPlano);
+    expect(result).toBe('Segunda, Quarta');
+  });
+});

--- a/src/app/pages/planos/plano-list/plano-list.component.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { PlanoService } from '../../../core/services/plano.service';
+import { PlanoResponseDTO, TIPO_LABEL, FREQUENCIA_LABEL, DIAS_SEMANA_LABEL } from '../../../core/models/plano';
+
+@Component({
+  selector: 'app-plano-list',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './plano-list.component.html',
+  styleUrl: './plano-list.component.scss'
+})
+export class PlanoListComponent implements OnInit {
+  pacienteId!: number;
+  planos: PlanoResponseDTO[] = [];
+  loading = false;
+  erro: string | null = null;
+  confirmarInativarId: number | null = null;
+
+  readonly tipoLabel = TIPO_LABEL;
+  readonly frequenciaLabel = FREQUENCIA_LABEL;
+  readonly diasLabel = DIAS_SEMANA_LABEL;
+
+  constructor(private service: PlanoService, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading = true;
+    this.erro = null;
+    this.service.listar(this.pacienteId).subscribe({
+      next: planos => {
+        this.planos = planos;
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar planos.';
+        this.loading = false;
+      }
+    });
+  }
+
+  confirmarInativar(id: number): void {
+    this.confirmarInativarId = id;
+  }
+
+  cancelarInativar(): void {
+    this.confirmarInativarId = null;
+  }
+
+  inativar(): void {
+    if (this.confirmarInativarId === null) return;
+    this.service.inativar(this.confirmarInativarId).subscribe({
+      next: () => {
+        this.confirmarInativarId = null;
+        this.carregar();
+      },
+      error: () => {
+        this.erro = 'Erro ao inativar plano.';
+        this.confirmarInativarId = null;
+      }
+    });
+  }
+
+  diasFormatados(plano: PlanoResponseDTO): string {
+    return plano.diasSemana.map(d => this.diasLabel[d]).join(', ');
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa os três novos módulos expostos pela API v3 do backend (Spring Boot), conforme documentação técnica: **Planos**, **Pagamentos** e **Aulas**.

---

## O que foi adicionado

### Modelos (`src/app/core/models/plano.ts`)
- `PlanoResponseDTO`, `PlanoRequestDTO`
- `PagamentoResponseDTO`, `PagamentoRequestDTO`
- `AulaResponseDTO`
- Tipos: `TipoPagamento`, `FrequenciaSemanal`, `DiaSemana`, `StatusPagamento`
- Constantes de label e mapa `frequência → número de dias esperados`

### Serviços
| Serviço | Endpoints |
|---------|-----------|
| `PlanoService` | `GET /pacientes/:id/planos`, `POST /pacientes/:id/planos`, `PATCH /planos/:id/inativar` |
| `PagamentoService` | `GET /pacientes/:id/pagamentos`, `POST /pagamentos`, `PATCH /pagamentos/:id/pagar` |
| `AulaService` | `GET /pacientes/:id/aulas`, `PATCH /aulas/:id/confirmar` |

### Componentes
| Componente | Função |
|------------|--------|
| `PlanoListComponent` | Tabela de planos com tipo, valor, frequência, dias, status e inativação |
| `PlanoFormComponent` | Formulário com seleção de tipo/frequência e checkboxes de dias; validação customizada (count deve corresponder à frequência) |
| `PagamentoListComponent` | Tabela de pagamentos com badge de status e modal para confirmar pagamento (com data) |
| `PagamentoFormComponent` | Dropdown de planos ativos + campos de período e vencimento |
| `AulaListComponent` | Listagem de aulas geradas com botão "Confirmar Presença" |

### Rotas
```
/pacientes/:id/planos
/pacientes/:id/planos/novo
/pacientes/:id/pagamentos
/pacientes/:id/pagamentos/novo
/pacientes/:id/aulas
```

### UX — PacienteDetailComponent
Adicionada seção **Gestão** com links de navegação para Planos, Pagamentos e Aulas do paciente.

### Testes (Karma + Jasmine)
- `plano.service.spec.ts`, `pagamento.service.spec.ts`, `aula.service.spec.ts`
- `plano-list.component.spec.ts`, `plano-form.component.spec.ts`
- `pagamento-list.component.spec.ts`, `aula-list.component.spec.ts`

---

## Plano de testes

- [ ] `npm test` — todos os specs devem passar
- [ ] Navegar para detalhe de um paciente e verificar seção "Gestão"
- [ ] Criar plano (validar que a quantidade de dias bloqueia submit se não bater com a frequência)
- [ ] Registrar pagamento (verificar dropdown de planos ativos)
- [ ] Confirmar pagamento PENDENTE → verificar que status muda para PAGO
- [ ] Acessar aulas geradas e confirmar presença

https://claude.ai/code/session_01LM5pasWh4astegpoUBgtBt