### PR TITLE
feat: align frontend with new API and add professionals

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
   </div>
   <ul class="navbar-menu">
     <li><a routerLink="/pacientes">Pacientes</a></li>
+    <li><a routerLink="/profissionais">Profissionais</a></li>
   </ul>
 </nav>
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,29 +18,54 @@ export const routes: Routes = [
       import('./pages/pacientes/paciente-form/paciente-form.component').then(m => m.PacienteFormComponent)
   },
   {
-    path: 'pacientes/:id/planos/novo',
+    path: 'planos/novo/:pacienteId',
     loadComponent: () =>
       import('./pages/planos/plano-form/plano-form.component').then(m => m.PlanoFormComponent)
   },
   {
-    path: 'pacientes/:id/planos',
+    path: 'planos/paciente/:pacienteId',
     loadComponent: () =>
       import('./pages/planos/plano-list/plano-list.component').then(m => m.PlanoListComponent)
   },
   {
-    path: 'pacientes/:id/pagamentos/novo',
+    path: 'pagamentos/novo/:pacienteId',
     loadComponent: () =>
       import('./pages/pagamentos/pagamento-form/pagamento-form.component').then(m => m.PagamentoFormComponent)
   },
   {
-    path: 'pacientes/:id/pagamentos',
+    path: 'pagamentos/paciente/:pacienteId',
     loadComponent: () =>
       import('./pages/pagamentos/pagamento-list/pagamento-list.component').then(m => m.PagamentoListComponent)
   },
   {
-    path: 'pacientes/:id/aulas',
+    path: 'aulas/paciente/:pacienteId',
     loadComponent: () =>
       import('./pages/aulas/aula-list/aula-list.component').then(m => m.AulaListComponent)
+  },
+  {
+    path: 'aulas/pagamento/:pagamentoId',
+    loadComponent: () =>
+      import('./pages/aulas/aula-list/aula-list.component').then(m => m.AulaListComponent)
+  },
+  {
+    path: 'profissionais',
+    loadComponent: () =>
+      import('./pages/profissionais/profissional-list/profissional-list.component').then(m => m.ProfissionalListComponent)
+  },
+  {
+    path: 'profissionais/novo',
+    loadComponent: () =>
+      import('./pages/profissionais/profissional-form/profissional-form.component').then(m => m.ProfissionalFormComponent)
+  },
+  {
+    path: 'profissionais/:id/editar',
+    loadComponent: () =>
+      import('./pages/profissionais/profissional-form/profissional-form.component').then(m => m.ProfissionalFormComponent)
+  },
+  {
+    path: 'profissionais/:id',
+    loadComponent: () =>
+      import('./pages/profissionais/profissional-detail/profissional-detail.component').then(m => m.ProfissionalDetailComponent)
   },
   {
     path: 'pacientes/:id',

--- a/src/app/core/models/plano.ts
+++ b/src/app/core/models/plano.ts
@@ -15,6 +15,7 @@ export interface PlanoResponseDTO {
 }
 
 export interface PlanoRequestDTO {
+  pacienteId: number;
   tipo: TipoPagamento;
   valor: number;
   frequenciaSemanal: FrequenciaSemanal;
@@ -25,6 +26,7 @@ export interface PlanoRequestDTO {
 export interface PagamentoResponseDTO {
   id: number;
   pacienteId: number;
+  pacienteNome: string;
   planoId: number;
   valor: number;
   status: StatusPagamento;
@@ -35,16 +37,17 @@ export interface PagamentoResponseDTO {
 }
 
 export interface PagamentoRequestDTO {
+  pacienteId: number;
   planoId: number;
   valor: number;
   dataVencimento: string;
   periodoInicio: string;
-  periodoFim: string;
 }
 
 export interface AulaResponseDTO {
   id: number;
   pacienteId: number;
+  pacienteNome: string;
   pagamentoId: number;
   data: string;
   realizada: boolean;

--- a/src/app/core/models/profissional.ts
+++ b/src/app/core/models/profissional.ts
@@ -1,0 +1,42 @@
+import { Page } from './paciente';
+
+export type TipoContrato = 'CLT' | 'PJ' | 'AUTONOMO';
+
+export interface ProfissionalResponseDTO {
+  id: number;
+  nome: string;
+  email: string;
+  cpf: string;
+  telefone: string | null;
+  tipoContrato: TipoContrato;
+  percentualPagamentoAula: number;
+  dataInicio: string;
+  ativo: boolean;
+}
+
+export interface ProfissionalRequestDTO {
+  nome: string;
+  email: string;
+  cpf: string;
+  telefone?: string;
+  tipoContrato: TipoContrato;
+  percentualPagamentoAula: number;
+  dataInicio: string;
+}
+
+export interface ProfissionalUpdateDTO {
+  nome?: string;
+  email?: string;
+  telefone?: string;
+  tipoContrato?: TipoContrato;
+  percentualPagamentoAula?: number;
+  dataInicio?: string;
+}
+
+export type ProfissionalPage = Page<ProfissionalResponseDTO>;
+
+export const TIPO_CONTRATO_LABEL: Record<TipoContrato, string> = {
+  CLT: 'CLT',
+  PJ: 'PJ',
+  AUTONOMO: 'Autônomo'
+};

--- a/src/app/core/services/aula.service.spec.ts
+++ b/src/app/core/services/aula.service.spec.ts
@@ -6,6 +6,7 @@ import { AulaResponseDTO } from '../models/plano';
 const mockAula: AulaResponseDTO = {
   id: 1,
   pacienteId: 10,
+  pacienteNome: 'Ana Silva',
   pagamentoId: 1,
   data: '2026-05-05',
   realizada: false
@@ -30,21 +31,30 @@ describe('AulaService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('listar', () => {
-    it('should GET /api/pacientes/:id/aulas', () => {
-      service.listar(10).subscribe(aulas => expect(aulas).toEqual([mockAula]));
-      const req = httpMock.expectOne('/api/pacientes/10/aulas');
+  describe('listarPorPaciente', () => {
+    it('should GET /api/aulas/paciente/:id', () => {
+      service.listarPorPaciente(10).subscribe(aulas => expect(aulas).toEqual([mockAula]));
+      const req = httpMock.expectOne('/api/aulas/paciente/10');
       expect(req.request.method).toBe('GET');
       req.flush([mockAula]);
     });
   });
 
-  describe('confirmar', () => {
-    it('should PATCH /api/aulas/:id/confirmar', () => {
-      service.confirmar(1).subscribe();
-      const req = httpMock.expectOne('/api/aulas/1/confirmar');
+  describe('listarPorPagamento', () => {
+    it('should GET /api/aulas/pagamento/:id', () => {
+      service.listarPorPagamento(1).subscribe(aulas => expect(aulas).toEqual([mockAula]));
+      const req = httpMock.expectOne('/api/aulas/pagamento/1');
+      expect(req.request.method).toBe('GET');
+      req.flush([mockAula]);
+    });
+  });
+
+  describe('realizar', () => {
+    it('should PATCH /api/aulas/:id/realizar', () => {
+      service.realizar(1).subscribe(aula => expect(aula).toEqual(mockAula));
+      const req = httpMock.expectOne('/api/aulas/1/realizar');
       expect(req.request.method).toBe('PATCH');
-      req.flush(null);
+      req.flush(mockAula);
     });
   });
 });

--- a/src/app/core/services/aula.service.ts
+++ b/src/app/core/services/aula.service.ts
@@ -9,11 +9,15 @@ export class AulaService {
 
   constructor(private http: HttpClient) {}
 
-  listar(pacienteId: number): Observable<AulaResponseDTO[]> {
-    return this.http.get<AulaResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/aulas`);
+  listarPorPaciente(pacienteId: number): Observable<AulaResponseDTO[]> {
+    return this.http.get<AulaResponseDTO[]>(`${this.apiUrl}/aulas/paciente/${pacienteId}`);
   }
 
-  confirmar(aulaId: number): Observable<void> {
-    return this.http.patch<void>(`${this.apiUrl}/aulas/${aulaId}/confirmar`, {});
+  listarPorPagamento(pagamentoId: number): Observable<AulaResponseDTO[]> {
+    return this.http.get<AulaResponseDTO[]>(`${this.apiUrl}/aulas/pagamento/${pagamentoId}`);
+  }
+
+  realizar(aulaId: number): Observable<AulaResponseDTO> {
+    return this.http.patch<AulaResponseDTO>(`${this.apiUrl}/aulas/${aulaId}/realizar`, {});
   }
 }

--- a/src/app/core/services/pagamento.service.spec.ts
+++ b/src/app/core/services/pagamento.service.spec.ts
@@ -6,6 +6,7 @@ import { PagamentoRequestDTO, PagamentoResponseDTO } from '../models/plano';
 const mockPagamento: PagamentoResponseDTO = {
   id: 1,
   pacienteId: 10,
+  pacienteNome: 'Ana Silva',
   planoId: 1,
   valor: 250,
   status: 'PENDENTE',
@@ -35,9 +36,9 @@ describe('PagamentoService', () => {
   });
 
   describe('listar', () => {
-    it('should GET /api/pacientes/:id/pagamentos', () => {
+    it('should GET /api/pagamentos/paciente/:id', () => {
       service.listar(10).subscribe(p => expect(p).toEqual([mockPagamento]));
-      const req = httpMock.expectOne('/api/pacientes/10/pagamentos');
+      const req = httpMock.expectOne('/api/pagamentos/paciente/10');
       expect(req.request.method).toBe('GET');
       req.flush([mockPagamento]);
     });
@@ -46,11 +47,11 @@ describe('PagamentoService', () => {
   describe('criar', () => {
     it('should POST to /api/pagamentos with body', () => {
       const dto: PagamentoRequestDTO = {
+        pacienteId: 10,
         planoId: 1,
         valor: 250,
         dataVencimento: '2026-05-10',
-        periodoInicio: '2026-05-01',
-        periodoFim: '2026-05-31'
+        periodoInicio: '2026-05-01'
       };
       service.criar(dto).subscribe(p => expect(p).toEqual(mockPagamento));
       const req = httpMock.expectOne('/api/pagamentos');
@@ -64,9 +65,10 @@ describe('PagamentoService', () => {
     it('should PATCH /api/pagamentos/:id/pagar with dataPagamento', () => {
       const pagoPagamento = { ...mockPagamento, status: 'PAGO' as const, dataPagamento: '2026-05-05' };
       service.pagar(1, '2026-05-05').subscribe(p => expect(p.status).toBe('PAGO'));
-      const req = httpMock.expectOne('/api/pagamentos/1/pagar');
+      const req = httpMock.expectOne(r => r.url === '/api/pagamentos/1/pagar');
       expect(req.request.method).toBe('PATCH');
-      expect(req.request.body).toEqual({ dataPagamento: '2026-05-05' });
+      expect(req.request.body).toEqual({});
+      expect(req.request.params.get('dataPagamento')).toBe('2026-05-05');
       req.flush(pagoPagamento);
     });
   });

--- a/src/app/core/services/pagamento.service.ts
+++ b/src/app/core/services/pagamento.service.ts
@@ -10,7 +10,11 @@ export class PagamentoService {
   constructor(private http: HttpClient) {}
 
   listar(pacienteId: number): Observable<PagamentoResponseDTO[]> {
-    return this.http.get<PagamentoResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/pagamentos`);
+    return this.http.get<PagamentoResponseDTO[]>(`${this.apiUrl}/pagamentos/paciente/${pacienteId}`);
+  }
+
+  buscar(pagamentoId: number): Observable<PagamentoResponseDTO> {
+    return this.http.get<PagamentoResponseDTO>(`${this.apiUrl}/pagamentos/${pagamentoId}`);
   }
 
   criar(dto: PagamentoRequestDTO): Observable<PagamentoResponseDTO> {
@@ -20,7 +24,8 @@ export class PagamentoService {
   pagar(pagamentoId: number, dataPagamento: string): Observable<PagamentoResponseDTO> {
     return this.http.patch<PagamentoResponseDTO>(
       `${this.apiUrl}/pagamentos/${pagamentoId}/pagar`,
-      { dataPagamento }
+      {},
+      { params: { dataPagamento } }
     );
   }
 }

--- a/src/app/core/services/plano.service.spec.ts
+++ b/src/app/core/services/plano.service.spec.ts
@@ -34,25 +34,26 @@ describe('PlanoService', () => {
   });
 
   describe('listar', () => {
-    it('should GET /api/pacientes/:id/planos', () => {
+    it('should GET /api/planos/paciente/:id', () => {
       service.listar(10).subscribe(planos => expect(planos).toEqual([mockPlano]));
-      const req = httpMock.expectOne('/api/pacientes/10/planos');
+      const req = httpMock.expectOne('/api/planos/paciente/10');
       expect(req.request.method).toBe('GET');
       req.flush([mockPlano]);
     });
   });
 
   describe('criar', () => {
-    it('should POST to /api/pacientes/:id/planos with body', () => {
+    it('should POST to /api/planos with body', () => {
       const dto: PlanoRequestDTO = {
+        pacienteId: 10,
         tipo: 'MENSAL',
         valor: 250,
         frequenciaSemanal: 'DUAS_VEZES',
         dataInicio: '2026-05-01',
         diasSemana: ['MONDAY', 'WEDNESDAY']
       };
-      service.criar(10, dto).subscribe(p => expect(p).toEqual(mockPlano));
-      const req = httpMock.expectOne('/api/pacientes/10/planos');
+      service.criar(dto).subscribe(p => expect(p).toEqual(mockPlano));
+      const req = httpMock.expectOne('/api/planos');
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual(dto);
       req.flush(mockPlano);
@@ -60,10 +61,10 @@ describe('PlanoService', () => {
   });
 
   describe('inativar', () => {
-    it('should PATCH /api/planos/:id/inativar', () => {
+    it('should DELETE /api/planos/:id', () => {
       service.inativar(1).subscribe();
-      const req = httpMock.expectOne('/api/planos/1/inativar');
-      expect(req.request.method).toBe('PATCH');
+      const req = httpMock.expectOne('/api/planos/1');
+      expect(req.request.method).toBe('DELETE');
       req.flush(null);
     });
   });

--- a/src/app/core/services/plano.service.spec.ts
+++ b/src/app/core/services/plano.service.spec.ts
@@ -60,6 +60,21 @@ describe('PlanoService', () => {
     });
   });
 
+  describe('buscarAtivo', () => {
+    it('should GET /api/planos/paciente/:id/ativo', () => {
+      service.buscarAtivo(10).subscribe(p => expect(p).toEqual(mockPlano));
+      const req = httpMock.expectOne('/api/planos/paciente/10/ativo');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockPlano);
+    });
+
+    it('should return null when no active plan exists', () => {
+      service.buscarAtivo(10).subscribe(p => expect(p).toBeNull());
+      const req = httpMock.expectOne('/api/planos/paciente/10/ativo');
+      req.flush(null);
+    });
+  });
+
   describe('inativar', () => {
     it('should DELETE /api/planos/:id', () => {
       service.inativar(1).subscribe();

--- a/src/app/core/services/plano.service.ts
+++ b/src/app/core/services/plano.service.ts
@@ -10,14 +10,18 @@ export class PlanoService {
   constructor(private http: HttpClient) {}
 
   listar(pacienteId: number): Observable<PlanoResponseDTO[]> {
-    return this.http.get<PlanoResponseDTO[]>(`${this.apiUrl}/pacientes/${pacienteId}/planos`);
+    return this.http.get<PlanoResponseDTO[]>(`${this.apiUrl}/planos/paciente/${pacienteId}`);
   }
 
-  criar(pacienteId: number, dto: PlanoRequestDTO): Observable<PlanoResponseDTO> {
-    return this.http.post<PlanoResponseDTO>(`${this.apiUrl}/pacientes/${pacienteId}/planos`, dto);
+  buscarAtivo(pacienteId: number): Observable<PlanoResponseDTO | null> {
+    return this.http.get<PlanoResponseDTO | null>(`${this.apiUrl}/planos/paciente/${pacienteId}/ativo`);
+  }
+
+  criar(dto: PlanoRequestDTO): Observable<PlanoResponseDTO> {
+    return this.http.post<PlanoResponseDTO>(`${this.apiUrl}/planos`, dto);
   }
 
   inativar(planoId: number): Observable<void> {
-    return this.http.patch<void>(`${this.apiUrl}/planos/${planoId}/inativar`, {});
+    return this.http.delete<void>(`${this.apiUrl}/planos/${planoId}`);
   }
 }

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -85,13 +85,13 @@ describe('ProfissionalService', () => {
     req.flush(mockProfissional);
   });
 
-  it('should PUT /api/profissionais/:id', () => {
+  it('should PATCH /api/profissionais/:id', () => {
     const dto: ProfissionalUpdateDTO = { nome: 'Paula Atualizada', percentualPagamentoAula: 50 };
 
     service.atualizar(1, dto).subscribe(item => expect(item).toEqual(mockProfissional));
 
     const req = httpMock.expectOne('/api/profissionais/1');
-    expect(req.request.method).toBe('PUT');
+    expect(req.request.method).toBe('PATCH');
     expect(req.request.body).toEqual(dto);
     req.flush(mockProfissional);
   });

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ProfissionalService } from './profissional.service';
+import {
+  ProfissionalPage,
+  ProfissionalRequestDTO,
+  ProfissionalResponseDTO,
+  ProfissionalUpdateDTO
+} from '../models/profissional';
+
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 1,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+const mockPage: ProfissionalPage = {
+  content: [mockProfissional],
+  totalElements: 1,
+  totalPages: 1,
+  size: 10,
+  number: 0
+};
+
+describe('ProfissionalService', () => {
+  let service: ProfissionalService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ProfissionalService]
+    });
+    service = TestBed.inject(ProfissionalService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should GET /api/profissionais with default params', () => {
+    service.listar().subscribe(page => expect(page.content).toEqual([mockProfissional]));
+
+    const req = httpMock.expectOne(r => r.url === '/api/profissionais');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('page')).toBe('0');
+    expect(req.request.params.get('size')).toBe('10');
+    expect(req.request.params.get('sort')).toBe('nome');
+    req.flush(mockPage);
+  });
+
+  it('should GET /api/profissionais/:id', () => {
+    service.buscar(1).subscribe(item => expect(item).toEqual(mockProfissional));
+
+    const req = httpMock.expectOne('/api/profissionais/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockProfissional);
+  });
+
+  it('should POST /api/profissionais', () => {
+    const dto: ProfissionalRequestDTO = {
+      nome: 'Paula Mendes',
+      email: 'paula@carlessopilates.com',
+      cpf: '123.456.111-00',
+      telefone: '(11) 98888-1111',
+      tipoContrato: 'PJ',
+      percentualPagamentoAula: 45,
+      dataInicio: '2024-01-15'
+    };
+
+    service.cadastrar(dto).subscribe(item => expect(item).toEqual(mockProfissional));
+
+    const req = httpMock.expectOne('/api/profissionais');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(dto);
+    req.flush(mockProfissional);
+  });
+
+  it('should PUT /api/profissionais/:id', () => {
+    const dto: ProfissionalUpdateDTO = { nome: 'Paula Atualizada', percentualPagamentoAula: 50 };
+
+    service.atualizar(1, dto).subscribe(item => expect(item).toEqual(mockProfissional));
+
+    const req = httpMock.expectOne('/api/profissionais/1');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual(dto);
+    req.flush(mockProfissional);
+  });
+
+  it('should PATCH /api/profissionais/:id/ativar', () => {
+    service.ativar(1).subscribe();
+
+    const req = httpMock.expectOne('/api/profissionais/1/ativar');
+    expect(req.request.method).toBe('PATCH');
+    req.flush(null);
+  });
+
+  it('should PATCH /api/profissionais/:id/inativar', () => {
+    service.inativar(1).subscribe();
+
+    const req = httpMock.expectOne('/api/profissionais/1/inativar');
+    expect(req.request.method).toBe('PATCH');
+    req.flush(null);
+  });
+});

--- a/src/app/core/services/profissional.service.ts
+++ b/src/app/core/services/profissional.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  ProfissionalPage,
+  ProfissionalRequestDTO,
+  ProfissionalResponseDTO,
+  ProfissionalUpdateDTO
+} from '../models/profissional';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProfissionalService {
+  private readonly apiUrl = '/api/profissionais';
+
+  constructor(private http: HttpClient) {}
+
+  listar(page = 0, size = 10): Observable<ProfissionalPage> {
+    const params = new HttpParams().set('page', page).set('size', size).set('sort', 'nome');
+    return this.http.get<ProfissionalPage>(this.apiUrl, { params });
+  }
+
+  buscar(id: number): Observable<ProfissionalResponseDTO> {
+    return this.http.get<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`);
+  }
+
+  cadastrar(dto: ProfissionalRequestDTO): Observable<ProfissionalResponseDTO> {
+    return this.http.post<ProfissionalResponseDTO>(this.apiUrl, dto);
+  }
+
+  atualizar(id: number, dto: ProfissionalUpdateDTO): Observable<ProfissionalResponseDTO> {
+    return this.http.put<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`, dto);
+  }
+
+  ativar(id: number): Observable<void> {
+    return this.http.patch<void>(`${this.apiUrl}/${id}/ativar`, {});
+  }
+
+  inativar(id: number): Observable<void> {
+    return this.http.patch<void>(`${this.apiUrl}/${id}/inativar`, {});
+  }
+}

--- a/src/app/core/services/profissional.service.ts
+++ b/src/app/core/services/profissional.service.ts
@@ -30,7 +30,7 @@ export class ProfissionalService {
   }
 
   atualizar(id: number, dto: ProfissionalUpdateDTO): Observable<ProfissionalResponseDTO> {
-    return this.http.put<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`, dto);
+    return this.http.patch<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`, dto);
   }
 
   ativar(id: number): Observable<void> {

--- a/src/app/pages/aulas/aula-list/aula-list.component.html
+++ b/src/app/pages/aulas/aula-list/aula-list.component.html
@@ -1,6 +1,7 @@
 <div class="page-header">
-  <h1>Aulas do Paciente</h1>
-  <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
+  <h1>{{ titulo }}</h1>
+  <a *ngIf="pacienteId !== null" [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
+  <a *ngIf="pagamentoId !== null && pacienteId !== null" [routerLink]="['/pagamentos/paciente', pacienteId]" class="btn btn-outline">Voltar aos Pagamentos</a>
 </div>
 
 <div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
@@ -27,8 +28,8 @@
         </span>
       </td>
       <td>
-        <button class="btn btn-secondary btn-sm" *ngIf="!aula.realizada" (click)="confirmar(aula.id)">
-          Confirmar Presença
+        <button class="btn btn-secondary btn-sm" *ngIf="!aula.realizada" (click)="realizar(aula.id)">
+          Marcar como Realizada
         </button>
       </td>
     </tr>

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { registerLocaleData } from '@angular/common';
+import localePt from '@angular/common/locales/pt';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -7,8 +9,10 @@ import { AulaService } from '../../../core/services/aula.service';
 import { AulaResponseDTO } from '../../../core/models/plano';
 
 const mockAula: AulaResponseDTO = {
-  id: 1, pacienteId: 10, pagamentoId: 1, data: '2026-05-05', realizada: false
+  id: 1, pacienteId: 10, pacienteNome: 'Ana Silva', pagamentoId: 1, data: '2026-05-05', realizada: false
 };
+
+registerLocaleData(localePt);
 
 describe('AulaListComponent', () => {
   let component: AulaListComponent;
@@ -16,14 +20,14 @@ describe('AulaListComponent', () => {
   let serviceSpy: jasmine.SpyObj<AulaService>;
 
   beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('AulaService', ['listar', 'confirmar']);
-    serviceSpy.listar.and.returnValue(of([mockAula]));
+    serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
+    serviceSpy.listarPorPaciente.and.returnValue(of([mockAula]));
 
     await TestBed.configureTestingModule({
       imports: [AulaListComponent, RouterTestingModule],
       providers: [
         { provide: AulaService, useValue: serviceSpy },
-        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
       ]
     }).compileComponents();
 
@@ -35,27 +39,49 @@ describe('AulaListComponent', () => {
   it('should create', () => expect(component).toBeTruthy());
 
   it('should load aulas on init', () => {
-    expect(serviceSpy.listar).toHaveBeenCalledWith(10);
+    expect(serviceSpy.listarPorPaciente).toHaveBeenCalledWith(10);
     expect(component.aulas).toEqual([mockAula]);
     expect(component.loading).toBeFalse();
   });
 
   it('should set erro when listar fails', () => {
-    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    serviceSpy.listarPorPaciente.and.returnValue(throwError(() => new Error('fail')));
     component.carregar();
     expect(component.erro).toBe('Erro ao carregar aulas.');
   });
 
-  it('should call confirmar and reload on success', () => {
-    serviceSpy.confirmar.and.returnValue(of(undefined));
-    component.confirmar(1);
-    expect(serviceSpy.confirmar).toHaveBeenCalledWith(1);
-    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  it('should call realizar and reload on success', () => {
+    serviceSpy.realizar.and.returnValue(of({ ...mockAula, realizada: true }));
+    component.realizar(1);
+    expect(serviceSpy.realizar).toHaveBeenCalledWith(1);
+    expect(serviceSpy.listarPorPaciente).toHaveBeenCalledTimes(2);
   });
 
-  it('should set erro when confirmar fails', () => {
-    serviceSpy.confirmar.and.returnValue(throwError(() => new Error('fail')));
-    component.confirmar(1);
-    expect(component.erro).toBe('Erro ao confirmar presença.');
+  it('should set erro when realizar fails', () => {
+    serviceSpy.realizar.and.returnValue(throwError(() => new Error('fail')));
+    component.realizar(1);
+    expect(component.erro).toBe('Erro ao marcar aula como realizada.');
+  });
+
+  it('should load aulas by pagamento when pagamentoId is present', async () => {
+    const pagamentoRoute = { snapshot: { paramMap: { get: (key: string) => key === 'pagamentoId' ? '1' : null } } };
+    serviceSpy.listarPorPagamento.and.returnValue(of([mockAula]));
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [AulaListComponent, RouterTestingModule],
+      providers: [
+        { provide: AulaService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: pagamentoRoute }
+      ]
+    }).compileComponents();
+
+    const pagamentoFixture = TestBed.createComponent(AulaListComponent);
+    const pagamentoComponent = pagamentoFixture.componentInstance;
+    pagamentoFixture.detectChanges();
+
+    expect(serviceSpy.listarPorPagamento).toHaveBeenCalledWith(1);
+    expect(pagamentoComponent.titulo).toBe('Aulas do Pagamento');
+    expect(pagamentoComponent.pacienteId).toBe(10);
   });
 });

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -6,82 +6,112 @@ import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { AulaListComponent } from './aula-list.component';
 import { AulaService } from '../../../core/services/aula.service';
-import { AulaResponseDTO } from '../../../core/models/plano';
+import { PagamentoService } from '../../../core/services/pagamento.service';
+import { AulaResponseDTO, PagamentoResponseDTO } from '../../../core/models/plano';
 
 const mockAula: AulaResponseDTO = {
   id: 1, pacienteId: 10, pacienteNome: 'Ana Silva', pagamentoId: 1, data: '2026-05-05', realizada: false
 };
 
+const mockPagamento: PagamentoResponseDTO = {
+  id: 1, pacienteId: 10, pacienteNome: 'Ana Silva', planoId: 1,
+  valor: 250, status: 'PENDENTE', dataPagamento: null,
+  dataVencimento: '2026-05-10', periodoInicio: '2026-05-01', periodoFim: '2026-05-31'
+};
+
 registerLocaleData(localePt);
 
 describe('AulaListComponent', () => {
-  let component: AulaListComponent;
-  let fixture: ComponentFixture<AulaListComponent>;
-  let serviceSpy: jasmine.SpyObj<AulaService>;
+  describe('when route has pacienteId', () => {
+    let component: AulaListComponent;
+    let fixture: ComponentFixture<AulaListComponent>;
+    let serviceSpy: jasmine.SpyObj<AulaService>;
+    let pagamentoServiceSpy: jasmine.SpyObj<PagamentoService>;
 
-  beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
-    serviceSpy.listarPorPaciente.and.returnValue(of([mockAula]));
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
+      pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+      serviceSpy.listarPorPaciente.and.returnValue(of([mockAula]));
 
-    await TestBed.configureTestingModule({
-      imports: [AulaListComponent, RouterTestingModule],
-      providers: [
-        { provide: AulaService, useValue: serviceSpy },
-        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
-      ]
-    }).compileComponents();
+      await TestBed.configureTestingModule({
+        imports: [AulaListComponent, RouterTestingModule],
+        providers: [
+          { provide: AulaService, useValue: serviceSpy },
+          { provide: PagamentoService, useValue: pagamentoServiceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+        ]
+      }).compileComponents();
 
-    fixture = TestBed.createComponent(AulaListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      fixture = TestBed.createComponent(AulaListComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => expect(component).toBeTruthy());
+
+    it('should load aulas on init', () => {
+      expect(serviceSpy.listarPorPaciente).toHaveBeenCalledWith(10);
+      expect(component.aulas).toEqual([mockAula]);
+      expect(component.loading).toBeFalse();
+    });
+
+    it('should set erro when listar fails', () => {
+      serviceSpy.listarPorPaciente.and.returnValue(throwError(() => new Error('fail')));
+      component.carregar();
+      expect(component.erro).toBe('Erro ao carregar aulas.');
+    });
+
+    it('should call realizar and reload on success', () => {
+      serviceSpy.realizar.and.returnValue(of({ ...mockAula, realizada: true }));
+      component.realizar(1);
+      expect(serviceSpy.realizar).toHaveBeenCalledWith(1);
+      expect(serviceSpy.listarPorPaciente).toHaveBeenCalledTimes(2);
+    });
+
+    it('should set erro when realizar fails', () => {
+      serviceSpy.realizar.and.returnValue(throwError(() => new Error('fail')));
+      component.realizar(1);
+      expect(component.erro).toBe('Erro ao marcar aula como realizada.');
+    });
   });
 
-  it('should create', () => expect(component).toBeTruthy());
+  describe('when route has pagamentoId', () => {
+    let component: AulaListComponent;
+    let fixture: ComponentFixture<AulaListComponent>;
+    let serviceSpy: jasmine.SpyObj<AulaService>;
+    let pagamentoServiceSpy: jasmine.SpyObj<PagamentoService>;
 
-  it('should load aulas on init', () => {
-    expect(serviceSpy.listarPorPaciente).toHaveBeenCalledWith(10);
-    expect(component.aulas).toEqual([mockAula]);
-    expect(component.loading).toBeFalse();
-  });
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
+      pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+      serviceSpy.listarPorPagamento.and.returnValue(of([mockAula]));
+      pagamentoServiceSpy.buscar.and.returnValue(of(mockPagamento));
 
-  it('should set erro when listar fails', () => {
-    serviceSpy.listarPorPaciente.and.returnValue(throwError(() => new Error('fail')));
-    component.carregar();
-    expect(component.erro).toBe('Erro ao carregar aulas.');
-  });
+      await TestBed.configureTestingModule({
+        imports: [AulaListComponent, RouterTestingModule],
+        providers: [
+          { provide: AulaService, useValue: serviceSpy },
+          { provide: PagamentoService, useValue: pagamentoServiceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pagamentoId' ? '1' : null } } } }
+        ]
+      }).compileComponents();
 
-  it('should call realizar and reload on success', () => {
-    serviceSpy.realizar.and.returnValue(of({ ...mockAula, realizada: true }));
-    component.realizar(1);
-    expect(serviceSpy.realizar).toHaveBeenCalledWith(1);
-    expect(serviceSpy.listarPorPaciente).toHaveBeenCalledTimes(2);
-  });
+      fixture = TestBed.createComponent(AulaListComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
-  it('should set erro when realizar fails', () => {
-    serviceSpy.realizar.and.returnValue(throwError(() => new Error('fail')));
-    component.realizar(1);
-    expect(component.erro).toBe('Erro ao marcar aula como realizada.');
-  });
+    it('should fetch payment to resolve pacienteId then load aulas', () => {
+      expect(pagamentoServiceSpy.buscar).toHaveBeenCalledWith(1);
+      expect(serviceSpy.listarPorPagamento).toHaveBeenCalledWith(1);
+      expect(component.pacienteId).toBe(10);
+      expect(component.titulo).toBe('Aulas do Pagamento');
+    });
 
-  it('should load aulas by pagamento when pagamentoId is present', async () => {
-    const pagamentoRoute = { snapshot: { paramMap: { get: (key: string) => key === 'pagamentoId' ? '1' : null } } };
-    serviceSpy.listarPorPagamento.and.returnValue(of([mockAula]));
-
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [AulaListComponent, RouterTestingModule],
-      providers: [
-        { provide: AulaService, useValue: serviceSpy },
-        { provide: ActivatedRoute, useValue: pagamentoRoute }
-      ]
-    }).compileComponents();
-
-    const pagamentoFixture = TestBed.createComponent(AulaListComponent);
-    const pagamentoComponent = pagamentoFixture.componentInstance;
-    pagamentoFixture.detectChanges();
-
-    expect(serviceSpy.listarPorPagamento).toHaveBeenCalledWith(1);
-    expect(pagamentoComponent.titulo).toBe('Aulas do Pagamento');
-    expect(pagamentoComponent.pacienteId).toBe(10);
+    it('should set erro when buscar payment fails', () => {
+      pagamentoServiceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+      component.ngOnInit();
+      expect(component.erro).toBe('Erro ao carregar dados do pagamento.');
+    });
   });
 });

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -11,24 +11,38 @@ import { AulaResponseDTO } from '../../../core/models/plano';
   styleUrl: './aula-list.component.scss'
 })
 export class AulaListComponent implements OnInit {
-  pacienteId!: number;
+  pacienteId: number | null = null;
+  pagamentoId: number | null = null;
   aulas: AulaResponseDTO[] = [];
   loading = false;
   erro: string | null = null;
+  titulo = 'Aulas';
 
   constructor(private service: AulaService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    const pacienteId = this.route.snapshot.paramMap.get('pacienteId');
+    const pagamentoId = this.route.snapshot.paramMap.get('pagamentoId');
+
+    this.pacienteId = pacienteId ? +pacienteId : null;
+    this.pagamentoId = pagamentoId ? +pagamentoId : null;
+    this.titulo = this.pagamentoId !== null ? 'Aulas do Pagamento' : 'Aulas do Paciente';
     this.carregar();
   }
 
   carregar(): void {
     this.loading = true;
     this.erro = null;
-    this.service.listar(this.pacienteId).subscribe({
+    const request$ = this.pagamentoId !== null
+      ? this.service.listarPorPagamento(this.pagamentoId)
+      : this.service.listarPorPaciente(this.pacienteId!);
+
+    request$.subscribe({
       next: aulas => {
         this.aulas = aulas;
+        if (this.pacienteId === null && aulas.length > 0) {
+          this.pacienteId = aulas[0].pacienteId;
+        }
         this.loading = false;
       },
       error: () => {
@@ -38,10 +52,10 @@ export class AulaListComponent implements OnInit {
     });
   }
 
-  confirmar(id: number): void {
-    this.service.confirmar(id).subscribe({
+  realizar(id: number): void {
+    this.service.realizar(id).subscribe({
       next: () => this.carregar(),
-      error: () => (this.erro = 'Erro ao confirmar presença.')
+      error: () => (this.erro = 'Erro ao marcar aula como realizada.')
     });
   }
 }

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AulaService } from '../../../core/services/aula.service';
+import { PagamentoService } from '../../../core/services/pagamento.service';
 import { AulaResponseDTO } from '../../../core/models/plano';
 
 @Component({
@@ -18,7 +19,11 @@ export class AulaListComponent implements OnInit {
   erro: string | null = null;
   titulo = 'Aulas';
 
-  constructor(private service: AulaService, private route: ActivatedRoute) {}
+  constructor(
+    private service: AulaService,
+    private pagamentoService: PagamentoService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {
     const pacienteId = this.route.snapshot.paramMap.get('pacienteId');
@@ -27,7 +32,20 @@ export class AulaListComponent implements OnInit {
     this.pacienteId = pacienteId ? +pacienteId : null;
     this.pagamentoId = pagamentoId ? +pagamentoId : null;
     this.titulo = this.pagamentoId !== null ? 'Aulas do Pagamento' : 'Aulas do Paciente';
-    this.carregar();
+
+    if (this.pagamentoId !== null) {
+      this.pagamentoService.buscar(this.pagamentoId).subscribe({
+        next: pagamento => {
+          this.pacienteId = pagamento.pacienteId;
+          this.carregar();
+        },
+        error: () => {
+          this.erro = 'Erro ao carregar dados do pagamento.';
+        }
+      });
+    } else {
+      this.carregar();
+    }
   }
 
   carregar(): void {
@@ -40,9 +58,6 @@ export class AulaListComponent implements OnInit {
     request$.subscribe({
       next: aulas => {
         this.aulas = aulas;
-        if (this.pacienteId === null && aulas.length > 0) {
-          this.pacienteId = aulas[0].pacienteId;
-        }
         this.loading = false;
       },
       error: () => {

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.html
@@ -67,15 +67,15 @@
   <section class="detail-section links-section">
     <h2>Gestão</h2>
     <div class="links-grid">
-      <a [routerLink]="['/pacientes', paciente.id, 'planos']" class="link-card">
+      <a [routerLink]="['/planos/paciente', paciente.id]" class="link-card">
         <span class="link-icon">📋</span>
         <span>Planos</span>
       </a>
-      <a [routerLink]="['/pacientes', paciente.id, 'pagamentos']" class="link-card">
+      <a [routerLink]="['/pagamentos/paciente', paciente.id]" class="link-card">
         <span class="link-icon">💳</span>
         <span>Pagamentos</span>
       </a>
-      <a [routerLink]="['/pacientes', paciente.id, 'aulas']" class="link-card">
+      <a [routerLink]="['/aulas/paciente', paciente.id]" class="link-card">
         <span class="link-icon">🗓</span>
         <span>Aulas</span>
       </a>

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.html
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.html
@@ -1,13 +1,13 @@
 <div class="page-header">
   <h1>Novo Pagamento</h1>
-  <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-outline">Voltar</a>
+  <a [routerLink]="['/pagamentos/paciente', pacienteId]" class="btn btn-outline">Voltar</a>
 </div>
 
 <div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
 <div *ngIf="carregando" class="loading">Carregando planos...</div>
 
 <div *ngIf="!carregando && planos.length === 0 && !erro" class="alert alert-warning">
-  Este paciente não possui planos ativos. <a [routerLink]="['/pacientes', pacienteId, 'planos', 'novo']">Criar um plano</a>.
+  Este paciente não possui planos ativos. <a [routerLink]="['/planos/novo', pacienteId]">Criar um plano</a>.
 </div>
 
 <form *ngIf="!carregando && planos.length > 0" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
@@ -40,11 +40,6 @@
         [class.is-invalid]="campo('periodoInicio')?.invalid && campo('periodoInicio')?.touched" />
     </div>
     <div class="form-group">
-      <label for="periodoFim">Fim do Período *</label>
-      <input id="periodoFim" formControlName="periodoFim" type="date" class="form-control"
-        [class.is-invalid]="campo('periodoFim')?.invalid && campo('periodoFim')?.touched" />
-    </div>
-    <div class="form-group">
       <label for="dataVencimento">Vencimento *</label>
       <input id="dataVencimento" formControlName="dataVencimento" type="date" class="form-control"
         [class.is-invalid]="campo('dataVencimento')?.invalid && campo('dataVencimento')?.touched" />
@@ -55,6 +50,6 @@
     <button type="submit" class="btn btn-primary" [disabled]="salvando">
       {{ salvando ? 'Salvando...' : 'Salvar' }}
     </button>
-    <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-outline">Cancelar</a>
+    <a [routerLink]="['/pagamentos/paciente', pacienteId]" class="btn btn-outline">Cancelar</a>
   </div>
 </form>

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PagamentoFormComponent } from './pagamento-form.component';
+import { PagamentoService } from '../../../core/services/pagamento.service';
+import { PlanoService } from '../../../core/services/plano.service';
+import { PagamentoResponseDTO, PlanoResponseDTO } from '../../../core/models/plano';
+
+const mockPlano: PlanoResponseDTO = {
+  id: 1,
+  pacienteId: 10,
+  tipo: 'MENSAL',
+  valor: 250,
+  frequenciaSemanal: 'DUAS_VEZES',
+  dataInicio: '2026-05-01',
+  diasSemana: ['MONDAY', 'WEDNESDAY'],
+  ativo: true
+};
+
+const mockPagamento: PagamentoResponseDTO = {
+  id: 1,
+  pacienteId: 10,
+  pacienteNome: 'Ana Silva',
+  planoId: 1,
+  valor: 250,
+  status: 'PENDENTE',
+  dataPagamento: null,
+  dataVencimento: '2026-05-10',
+  periodoInicio: '2026-05-01',
+  periodoFim: '2026-05-31'
+};
+
+describe('PagamentoFormComponent', () => {
+  let component: PagamentoFormComponent;
+  let fixture: ComponentFixture<PagamentoFormComponent>;
+  let pagamentoServiceSpy: jasmine.SpyObj<PagamentoService>;
+  let planoServiceSpy: jasmine.SpyObj<PlanoService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['criar']);
+    planoServiceSpy = jasmine.createSpyObj('PlanoService', ['listar']);
+    planoServiceSpy.listar.and.returnValue(of([mockPlano]));
+
+    await TestBed.configureTestingModule({
+      imports: [PagamentoFormComponent, RouterTestingModule],
+      providers: [
+        { provide: PagamentoService, useValue: pagamentoServiceSpy },
+        { provide: PlanoService, useValue: planoServiceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    fixture = TestBed.createComponent(PagamentoFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should load active planos on init', () => {
+    expect(planoServiceSpy.listar).toHaveBeenCalledWith(10);
+    expect(component.planos).toEqual([mockPlano]);
+  });
+
+  it('should initialize form without periodoFim', () => {
+    ['planoId', 'valor', 'dataVencimento', 'periodoInicio'].forEach(ctrl => {
+      expect(component.form.contains(ctrl)).toBeTrue();
+    });
+    expect(component.form.contains('periodoFim')).toBeFalse();
+  });
+
+  it('should call criar with pacienteId and navigate on valid submit', () => {
+    pagamentoServiceSpy.criar.and.returnValue(of(mockPagamento));
+    component.form.setValue({
+      planoId: '1',
+      valor: 250,
+      dataVencimento: '2026-05-10',
+      periodoInicio: '2026-05-01'
+    });
+
+    component.salvar();
+
+    expect(pagamentoServiceSpy.criar).toHaveBeenCalledWith({
+      pacienteId: 10,
+      planoId: 1,
+      valor: 250,
+      dataVencimento: '2026-05-10',
+      periodoInicio: '2026-05-01'
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['/pagamentos/paciente', 10]);
+  });
+
+  it('should not call criar when form is invalid', () => {
+    component.salvar();
+    expect(pagamentoServiceSpy.criar).not.toHaveBeenCalled();
+  });
+
+  it('should set erro when loading planos fails', () => {
+    planoServiceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregarPlanos();
+    expect(component.erro).toBe('Erro ao carregar planos.');
+  });
+
+  it('should set erro when criar fails', () => {
+    pagamentoServiceSpy.criar.and.returnValue(throwError(() => new Error('fail')));
+    component.form.setValue({
+      planoId: '1',
+      valor: 250,
+      dataVencimento: '2026-05-10',
+      periodoInicio: '2026-05-01'
+    });
+
+    component.salvar();
+
+    expect(component.erro).toBe('Erro ao registrar pagamento.');
+    expect(component.salvando).toBeFalse();
+  });
+});

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
@@ -31,13 +31,12 @@ export class PagamentoFormComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
     this.form = this.fb.group({
       planoId: [null, Validators.required],
       valor: [null, [Validators.required, Validators.min(0.01)]],
       dataVencimento: ['', Validators.required],
-      periodoInicio: ['', Validators.required],
-      periodoFim: ['', Validators.required]
+      periodoInicio: ['', Validators.required]
     });
     this.carregarPlanos();
   }
@@ -67,8 +66,12 @@ export class PagamentoFormComponent implements OnInit {
     }
     this.salvando = true;
     this.erro = null;
-    this.pagamentoService.criar({ ...this.form.value, planoId: +this.form.value.planoId }).subscribe({
-      next: () => this.router.navigate(['/pacientes', this.pacienteId, 'pagamentos']),
+    this.pagamentoService.criar({
+      ...this.form.value,
+      pacienteId: this.pacienteId,
+      planoId: +this.form.value.planoId
+    }).subscribe({
+      next: () => this.router.navigate(['/pagamentos/paciente', this.pacienteId]),
       error: () => {
         this.erro = 'Erro ao registrar pagamento.';
         this.salvando = false;

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h1>Pagamentos do Paciente</h1>
   <div class="acoes">
-    <a [routerLink]="['/pacientes', pacienteId, 'pagamentos', 'novo']" class="btn btn-primary">Novo Pagamento</a>
+    <a [routerLink]="['/pagamentos/novo', pacienteId]" class="btn btn-primary">Novo Pagamento</a>
     <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
   </div>
 </div>
@@ -39,6 +39,7 @@
         <button class="btn btn-secondary btn-sm" *ngIf="p.status === 'PENDENTE'" (click)="abrirPagar(p.id)">
           Confirmar Pagamento
         </button>
+        <a [routerLink]="['/aulas/pagamento', p.id]" class="btn btn-sm btn-outline">Ver Aulas</a>
       </td>
     </tr>
   </tbody>

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
@@ -22,12 +22,12 @@ describe('PagamentoListComponent', () => {
     serviceSpy.listar.and.returnValue(of([mockPagamento]));
 
     await TestBed.configureTestingModule({
-        imports: [PagamentoListComponent, RouterTestingModule],
-        providers: [
-          { provide: PagamentoService, useValue: serviceSpy },
-          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
-        ]
-      }).compileComponents();
+      imports: [PagamentoListComponent, RouterTestingModule],
+      providers: [
+        { provide: PagamentoService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PagamentoListComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
@@ -7,7 +7,7 @@ import { PagamentoService } from '../../../core/services/pagamento.service';
 import { PagamentoResponseDTO } from '../../../core/models/plano';
 
 const mockPagamento: PagamentoResponseDTO = {
-  id: 1, pacienteId: 10, planoId: 1, valor: 250, status: 'PENDENTE',
+  id: 1, pacienteId: 10, pacienteNome: 'Ana Silva', planoId: 1, valor: 250, status: 'PENDENTE',
   dataPagamento: null, dataVencimento: '2026-05-10',
   periodoInicio: '2026-05-01', periodoFim: '2026-05-31'
 };
@@ -22,12 +22,12 @@ describe('PagamentoListComponent', () => {
     serviceSpy.listar.and.returnValue(of([mockPagamento]));
 
     await TestBed.configureTestingModule({
-      imports: [PagamentoListComponent, RouterTestingModule],
-      providers: [
-        { provide: PagamentoService, useValue: serviceSpy },
-        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
-      ]
-    }).compileComponents();
+        imports: [PagamentoListComponent, RouterTestingModule],
+        providers: [
+          { provide: PagamentoService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+        ]
+      }).compileComponents();
 
     fixture = TestBed.createComponent(PagamentoListComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
@@ -32,7 +32,7 @@ export class PagamentoListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
     this.pagarForm = this.fb.group({ dataPagamento: ['', Validators.required] });
     this.carregar();
   }

--- a/src/app/pages/planos/plano-form/plano-form.component.html
+++ b/src/app/pages/planos/plano-form/plano-form.component.html
@@ -1,6 +1,6 @@
 <div class="page-header">
   <h1>Novo Plano</h1>
-  <a [routerLink]="['/pacientes', pacienteId, 'planos']" class="btn btn-outline">Voltar</a>
+  <a [routerLink]="['/planos/paciente', pacienteId]" class="btn btn-outline">Voltar</a>
 </div>
 
 <div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
@@ -67,6 +67,6 @@
     <button type="submit" class="btn btn-primary" [disabled]="salvando">
       {{ salvando ? 'Salvando...' : 'Salvar' }}
     </button>
-    <a [routerLink]="['/pacientes', pacienteId, 'planos']" class="btn btn-outline">Cancelar</a>
+    <a [routerLink]="['/planos/paciente', pacienteId]" class="btn btn-outline">Cancelar</a>
   </div>
 </form>

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -22,12 +22,12 @@ describe('PlanoFormComponent', () => {
     serviceSpy = jasmine.createSpyObj('PlanoService', ['criar']);
 
     await TestBed.configureTestingModule({
-        imports: [PlanoFormComponent, RouterTestingModule],
-        providers: [
-          { provide: PlanoService, useValue: serviceSpy },
-          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
-        ]
-      }).compileComponents();
+      imports: [PlanoFormComponent, RouterTestingModule],
+      providers: [
+        { provide: PlanoService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+      ]
+    }).compileComponents();
 
     router = TestBed.inject(Router);
     spyOn(router, 'navigate');

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -22,12 +22,12 @@ describe('PlanoFormComponent', () => {
     serviceSpy = jasmine.createSpyObj('PlanoService', ['criar']);
 
     await TestBed.configureTestingModule({
-      imports: [PlanoFormComponent, RouterTestingModule],
-      providers: [
-        { provide: PlanoService, useValue: serviceSpy },
-        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
-      ]
-    }).compileComponents();
+        imports: [PlanoFormComponent, RouterTestingModule],
+        providers: [
+          { provide: PlanoService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
+        ]
+      }).compileComponents();
 
     router = TestBed.inject(Router);
     spyOn(router, 'navigate');
@@ -82,8 +82,8 @@ describe('PlanoFormComponent', () => {
       diasSemana: ['MONDAY', 'WEDNESDAY']
     });
     component.salvar();
-    expect(serviceSpy.criar).toHaveBeenCalledWith(10, component.form.value);
-    expect(router.navigate).toHaveBeenCalledWith(['/pacientes', 10, 'planos']);
+    expect(serviceSpy.criar).toHaveBeenCalledWith({ ...component.form.value, pacienteId: 10 });
+    expect(router.navigate).toHaveBeenCalledWith(['/planos/paciente', 10]);
   });
 
   it('should set erro on criar failure', () => {

--- a/src/app/pages/planos/plano-form/plano-form.component.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.ts
@@ -40,7 +40,7 @@ export class PlanoFormComponent implements OnInit {
   constructor(private fb: FormBuilder, private service: PlanoService, private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
     this.form = this.fb.group({
       tipo: ['', Validators.required],
       valor: [null, [Validators.required, Validators.min(0.01)]],
@@ -79,8 +79,8 @@ export class PlanoFormComponent implements OnInit {
     }
     this.salvando = true;
     this.erro = null;
-    this.service.criar(this.pacienteId, this.form.value).subscribe({
-      next: () => this.router.navigate(['/pacientes', this.pacienteId, 'planos']),
+    this.service.criar({ ...this.form.value, pacienteId: this.pacienteId }).subscribe({
+      next: () => this.router.navigate(['/planos/paciente', this.pacienteId]),
       error: () => {
         this.erro = 'Erro ao salvar plano.';
         this.salvando = false;

--- a/src/app/pages/planos/plano-list/plano-list.component.html
+++ b/src/app/pages/planos/plano-list/plano-list.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h1>Planos do Paciente</h1>
   <div class="acoes">
-    <a [routerLink]="['/pacientes', pacienteId, 'planos', 'novo']" class="btn btn-primary">Novo Plano</a>
+    <a [routerLink]="['/planos/novo', pacienteId]" class="btn btn-primary">Novo Plano</a>
     <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
   </div>
 </div>
@@ -38,7 +38,7 @@
         </span>
       </td>
       <td class="acoes-col">
-        <a [routerLink]="['/pacientes', pacienteId, 'pagamentos']" class="btn btn-secondary btn-sm">Pagamentos</a>
+        <a [routerLink]="['/pagamentos/paciente', pacienteId]" class="btn btn-secondary btn-sm">Pagamentos</a>
         <button class="btn btn-danger btn-sm" *ngIf="plano.ativo" (click)="confirmarInativar(plano.id)">Inativar</button>
       </td>
     </tr>

--- a/src/app/pages/planos/plano-list/plano-list.component.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.ts
@@ -24,7 +24,7 @@ export class PlanoListComponent implements OnInit {
   constructor(private service: PlanoService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('id')!;
+    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
     this.carregar();
   }
 

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.html
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.html
@@ -1,0 +1,72 @@
+<div class="page-header" *ngIf="profissional">
+  <h1>{{ profissional.nome }}</h1>
+  <div class="acoes">
+    <a [routerLink]="['/profissionais', profissional.id, 'editar']" class="btn btn-secondary">Editar</a>
+    <button class="btn btn-secondary" (click)="confirmarAtivar = true" *ngIf="!profissional.ativo">Ativar</button>
+    <button class="btn btn-danger" (click)="confirmarInativar = true" *ngIf="profissional.ativo">Inativar</button>
+    <a routerLink="/profissionais" class="btn btn-outline">Voltar</a>
+  </div>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<div *ngIf="profissional" class="detail-card">
+  <div class="badge-status" [class.inativo]="!profissional.ativo">
+    {{ profissional.ativo ? 'Ativo' : 'Inativo' }}
+  </div>
+
+  <section class="detail-section">
+    <h2>Dados do Profissional</h2>
+    <div class="detail-grid">
+      <div class="detail-item">
+        <span class="label">Nome</span>
+        <span>{{ profissional.nome }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">E-mail</span>
+        <span>{{ profissional.email }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">CPF</span>
+        <span>{{ profissional.cpf }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">Telefone</span>
+        <span>{{ profissional.telefone || '-' }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">Contrato</span>
+        <span>{{ tipoContratoLabel[profissional.tipoContrato] }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">% por Aula</span>
+        <span>{{ profissional.percentualPagamentoAula }}%</span>
+      </div>
+      <div class="detail-item">
+        <span class="label">Data de Início</span>
+        <span>{{ profissional.dataInicio | date:'dd/MM/yyyy' }}</span>
+      </div>
+    </div>
+  </section>
+</div>
+
+<div class="dialog-overlay" *ngIf="confirmarAtivar">
+  <div class="dialog">
+    <p>Confirma a reativação de <strong>{{ profissional?.nome }}</strong>?</p>
+    <div class="dialog-actions">
+      <button class="btn btn-secondary" (click)="ativar()">Confirmar</button>
+      <button class="btn btn-outline" (click)="confirmarAtivar = false">Cancelar</button>
+    </div>
+  </div>
+</div>
+
+<div class="dialog-overlay" *ngIf="confirmarInativar">
+  <div class="dialog">
+    <p>Confirma a inativação de <strong>{{ profissional?.nome }}</strong>?</p>
+    <div class="dialog-actions">
+      <button class="btn btn-danger" (click)="inativar()">Confirmar</button>
+      <button class="btn btn-outline" (click)="confirmarInativar = false">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.scss
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.scss
@@ -1,0 +1,11 @@
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.acoes {
+  display: flex;
+  gap: .5rem;
+}

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { ProfissionalDetailComponent } from './profissional-detail.component';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { ProfissionalResponseDTO } from '../../../core/models/profissional';
+
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 1,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+describe('ProfissionalDetailComponent', () => {
+  let component: ProfissionalDetailComponent;
+  let fixture: ComponentFixture<ProfissionalDetailComponent>;
+  let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ProfissionalService', ['buscar', 'ativar', 'inativar']);
+    serviceSpy.buscar.and.returnValue(of(mockProfissional));
+
+    await TestBed.configureTestingModule({
+      imports: [ProfissionalDetailComponent, RouterTestingModule],
+      providers: [
+        { provide: ProfissionalService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    fixture = TestBed.createComponent(ProfissionalDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should load profissional on init', () => {
+    expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
+    expect(component.profissional).toEqual(mockProfissional);
+  });
+
+  it('should navigate after ativar succeeds', () => {
+    component.profissional = { ...mockProfissional, ativo: false };
+    serviceSpy.ativar.and.returnValue(of(undefined));
+    component.ativar();
+    expect(serviceSpy.ativar).toHaveBeenCalledWith(1);
+    expect(router.navigate).toHaveBeenCalledWith(['/profissionais']);
+  });
+
+  it('should navigate after inativar succeeds', () => {
+    serviceSpy.inativar.and.returnValue(of(undefined));
+    component.inativar();
+    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+    expect(router.navigate).toHaveBeenCalledWith(['/profissionais']);
+  });
+
+  it('should set erro when buscar fails', () => {
+    serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+    component.ngOnInit();
+    expect(component.erro).toBe('Profissional não encontrado.');
+  });
+
+  it('should set erro when ativar fails', () => {
+    component.profissional = { ...mockProfissional, ativo: false };
+    serviceSpy.ativar.and.returnValue(throwError(() => new Error('fail')));
+    component.ativar();
+    expect(component.erro).toBe('Erro ao ativar profissional.');
+  });
+
+  it('should set erro when inativar fails', () => {
+    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+    component.inativar();
+    expect(component.erro).toBe('Erro ao inativar profissional.');
+  });
+});

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.ts
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { ProfissionalResponseDTO, TIPO_CONTRATO_LABEL } from '../../../core/models/profissional';
+
+@Component({
+  selector: 'app-profissional-detail',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './profissional-detail.component.html',
+  styleUrl: './profissional-detail.component.scss'
+})
+export class ProfissionalDetailComponent implements OnInit {
+  profissional: ProfissionalResponseDTO | null = null;
+  loading = false;
+  erro: string | null = null;
+  confirmarAtivar = false;
+  confirmarInativar = false;
+
+  readonly tipoContratoLabel = TIPO_CONTRATO_LABEL;
+
+  constructor(
+    private service: ProfissionalService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) return;
+
+    this.loading = true;
+    this.service.buscar(+id).subscribe({
+      next: profissional => {
+        this.profissional = profissional;
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Profissional não encontrado.';
+        this.loading = false;
+      }
+    });
+  }
+
+  ativar(): void {
+    if (!this.profissional) return;
+
+    this.service.ativar(this.profissional.id).subscribe({
+      next: () => this.router.navigate(['/profissionais']),
+      error: () => (this.erro = 'Erro ao ativar profissional.')
+    });
+  }
+
+  inativar(): void {
+    if (!this.profissional) return;
+
+    this.service.inativar(this.profissional.id).subscribe({
+      next: () => this.router.navigate(['/profissionais']),
+      error: () => (this.erro = 'Erro ao inativar profissional.')
+    });
+  }
+}

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.html
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.html
@@ -1,0 +1,87 @@
+<div class="page-header">
+  <h1>{{ isEdit ? 'Editar Profissional' : 'Novo Profissional' }}</h1>
+  <a routerLink="/profissionais" class="btn btn-outline">Voltar</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<form *ngIf="!loading" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
+  <h2 class="form-section-title">Dados do Profissional</h2>
+
+  <div class="form-group">
+    <label for="nome">Nome *</label>
+    <input id="nome" formControlName="nome" type="text" class="form-control"
+      [class.is-invalid]="campo('nome')?.invalid && campo('nome')?.touched" />
+    <div class="invalid-feedback" *ngIf="campo('nome')?.errors?.['required'] && campo('nome')?.touched">
+      Nome é obrigatório.
+    </div>
+    <div class="invalid-feedback" *ngIf="campo('nome')?.errors?.['minlength'] && campo('nome')?.touched">
+      Nome deve ter ao menos 3 caracteres.
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="email">E-mail *</label>
+      <input id="email" formControlName="email" type="email" class="form-control"
+        [class.is-invalid]="campo('email')?.invalid && campo('email')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('email')?.touched && campo('email')?.invalid">
+        E-mail inválido.
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="cpf">CPF *</label>
+      <input id="cpf" formControlName="cpf" type="text" class="form-control"
+        [class.is-invalid]="campo('cpf')?.invalid && campo('cpf')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('cpf')?.touched && campo('cpf')?.invalid">
+        CPF é obrigatório.
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="telefone">Telefone</label>
+      <input id="telefone" formControlName="telefone" type="text" class="form-control" />
+    </div>
+    <div class="form-group">
+      <label for="tipoContrato">Tipo de Contrato *</label>
+      <select id="tipoContrato" formControlName="tipoContrato" class="form-control"
+        [class.is-invalid]="campo('tipoContrato')?.invalid && campo('tipoContrato')?.touched">
+        <option value="">Selecione...</option>
+        <option *ngFor="let tipo of tiposContrato" [value]="tipo">{{ tipoContratoLabel[tipo] }}</option>
+      </select>
+      <div class="invalid-feedback" *ngIf="campo('tipoContrato')?.invalid && campo('tipoContrato')?.touched">
+        Tipo de contrato é obrigatório.
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="form-group">
+      <label for="percentualPagamentoAula">% de Pagamento por Aula *</label>
+      <input id="percentualPagamentoAula" formControlName="percentualPagamentoAula" type="number"
+        min="0.01" max="100" step="0.01" class="form-control"
+        [class.is-invalid]="campo('percentualPagamentoAula')?.invalid && campo('percentualPagamentoAula')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('percentualPagamentoAula')?.invalid && campo('percentualPagamentoAula')?.touched">
+        Informe um percentual entre 0,01 e 100.
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="dataInicio">Data de Início *</label>
+      <input id="dataInicio" formControlName="dataInicio" type="date" class="form-control"
+        [class.is-invalid]="campo('dataInicio')?.invalid && campo('dataInicio')?.touched" />
+      <div class="invalid-feedback" *ngIf="campo('dataInicio')?.invalid && campo('dataInicio')?.touched">
+        Data é obrigatória.
+      </div>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button type="submit" class="btn btn-primary" [disabled]="salvando">
+      {{ salvando ? 'Salvando...' : 'Salvar' }}
+    </button>
+    <a routerLink="/profissionais" class="btn btn-outline">Cancelar</a>
+  </div>
+</form>

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.scss
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.scss
@@ -1,0 +1,12 @@
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #4a0080;
+  }
+}

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
@@ -1,0 +1,153 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { ProfissionalFormComponent } from './profissional-form.component';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { ProfissionalResponseDTO } from '../../../core/models/profissional';
+
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 1,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+describe('ProfissionalFormComponent', () => {
+  describe('in create mode', () => {
+    let component: ProfissionalFormComponent;
+    let fixture: ComponentFixture<ProfissionalFormComponent>;
+    let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+    let router: Router;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('ProfissionalService', ['cadastrar', 'buscar', 'atualizar']);
+
+      await TestBed.configureTestingModule({
+        imports: [ProfissionalFormComponent, RouterTestingModule],
+        providers: [
+          { provide: ProfissionalService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => null } } } }
+        ]
+      }).compileComponents();
+
+      router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      fixture = TestBed.createComponent(ProfissionalFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create with isEdit false', () => {
+      expect(component).toBeTruthy();
+      expect(component.isEdit).toBeFalse();
+    });
+
+    it('should initialize all form controls', () => {
+      ['nome', 'email', 'cpf', 'telefone', 'tipoContrato', 'percentualPagamentoAula', 'dataInicio'].forEach(ctrl => {
+        expect(component.form.contains(ctrl)).toBeTrue();
+      });
+    });
+
+    it('should call cadastrar and navigate on valid submit', () => {
+      serviceSpy.cadastrar.and.returnValue(of(mockProfissional));
+      component.form.patchValue({
+        nome: 'Paula Mendes',
+        email: 'paula@carlessopilates.com',
+        cpf: '123.456.111-00',
+        tipoContrato: 'PJ',
+        percentualPagamentoAula: 45,
+        dataInicio: '2024-01-15'
+      });
+      component.salvar();
+      expect(serviceSpy.cadastrar).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['/profissionais']);
+    });
+
+    it('should not call service when form is invalid', () => {
+      component.salvar();
+      expect(serviceSpy.cadastrar).not.toHaveBeenCalled();
+    });
+
+    it('should set erro on cadastrar failure', () => {
+      serviceSpy.cadastrar.and.returnValue(throwError(() => new Error('fail')));
+      component.form.patchValue({
+        nome: 'Paula Mendes',
+        email: 'paula@carlessopilates.com',
+        cpf: '123.456.111-00',
+        tipoContrato: 'PJ',
+        percentualPagamentoAula: 45,
+        dataInicio: '2024-01-15'
+      });
+      component.salvar();
+      expect(component.erro).toBe('Erro ao salvar profissional.');
+      expect(component.salvando).toBeFalse();
+    });
+  });
+
+  describe('in edit mode', () => {
+    let component: ProfissionalFormComponent;
+    let fixture: ComponentFixture<ProfissionalFormComponent>;
+    let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+    let router: Router;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('ProfissionalService', ['buscar', 'cadastrar', 'atualizar']);
+      serviceSpy.buscar.and.returnValue(of(mockProfissional));
+
+      await TestBed.configureTestingModule({
+        imports: [ProfissionalFormComponent, RouterTestingModule],
+        providers: [
+          { provide: ProfissionalService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
+        ]
+      }).compileComponents();
+
+      router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      fixture = TestBed.createComponent(ProfissionalFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should load profissional data on init', () => {
+      expect(component.isEdit).toBeTrue();
+      expect(serviceSpy.buscar).toHaveBeenCalledWith(1);
+      expect(component.form.get('nome')?.value).toBe('Paula Mendes');
+    });
+
+    it('should disable cpf field in edit mode', () => {
+      expect(component.form.get('cpf')?.disabled).toBeTrue();
+    });
+
+    it('should call atualizar and navigate on valid submit', () => {
+      serviceSpy.atualizar.and.returnValue(of(mockProfissional));
+      component.salvar();
+      expect(serviceSpy.atualizar).toHaveBeenCalledWith(
+        1,
+        jasmine.objectContaining({ nome: 'Paula Mendes', email: 'paula@carlessopilates.com' })
+      );
+      expect(router.navigate).toHaveBeenCalledWith(['/profissionais']);
+    });
+
+    it('should set erro on atualizar failure', () => {
+      serviceSpy.atualizar.and.returnValue(throwError(() => new Error('fail')));
+      component.salvar();
+      expect(component.erro).toBe('Erro ao salvar profissional.');
+      expect(component.salvando).toBeFalse();
+    });
+
+    it('should set erro when buscar fails', () => {
+      serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+      component.ngOnInit();
+      expect(component.erro).toBe('Erro ao carregar profissional.');
+    });
+  });
+});

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
@@ -1,0 +1,95 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { TIPO_CONTRATO_LABEL, TipoContrato } from '../../../core/models/profissional';
+
+@Component({
+  selector: 'app-profissional-form',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './profissional-form.component.html',
+  styleUrl: './profissional-form.component.scss'
+})
+export class ProfissionalFormComponent implements OnInit {
+  form!: FormGroup;
+  isEdit = false;
+  profissionalId: number | null = null;
+  loading = false;
+  salvando = false;
+  erro: string | null = null;
+
+  readonly tiposContrato: TipoContrato[] = ['CLT', 'PJ', 'AUTONOMO'];
+  readonly tipoContratoLabel = TIPO_CONTRATO_LABEL;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: ProfissionalService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      nome: ['', [Validators.required, Validators.minLength(3)]],
+      email: ['', [Validators.required, Validators.email]],
+      cpf: ['', Validators.required],
+      telefone: [''],
+      tipoContrato: ['', Validators.required],
+      percentualPagamentoAula: [null, [Validators.required, Validators.min(0.01), Validators.max(100)]],
+      dataInicio: ['', Validators.required]
+    });
+
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) return;
+
+    this.isEdit = true;
+    this.profissionalId = +id;
+    this.loading = true;
+    this.service.buscar(this.profissionalId).subscribe({
+      next: profissional => {
+        this.form.patchValue(profissional);
+        this.form.get('cpf')?.disable();
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar profissional.';
+        this.loading = false;
+      }
+    });
+  }
+
+  salvar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.salvando = true;
+    this.erro = null;
+    const valor = this.form.getRawValue();
+
+    const request$ = this.isEdit && this.profissionalId !== null
+      ? this.service.atualizar(this.profissionalId, {
+          nome: valor.nome,
+          email: valor.email,
+          telefone: valor.telefone,
+          tipoContrato: valor.tipoContrato,
+          percentualPagamentoAula: valor.percentualPagamentoAula,
+          dataInicio: valor.dataInicio
+        })
+      : this.service.cadastrar(valor);
+
+    request$.subscribe({
+      next: () => this.router.navigate(['/profissionais']),
+      error: () => {
+        this.erro = 'Erro ao salvar profissional.';
+        this.salvando = false;
+      }
+    });
+  }
+
+  campo(nome: string) {
+    return this.form.get(nome);
+  }
+}

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.html
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.html
@@ -1,0 +1,53 @@
+<div class="page-header">
+  <h1>Profissionais</h1>
+  <a routerLink="/profissionais/novo" class="btn btn-primary">+ Novo Profissional</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+
+<div *ngIf="loading" class="loading">Carregando...</div>
+
+<div *ngIf="!loading && profissionais.length === 0 && !erro" class="empty-state">
+  Nenhum profissional ativo cadastrado.
+</div>
+
+<table *ngIf="profissionais.length > 0" class="table">
+  <thead>
+    <tr>
+      <th>Nome</th>
+      <th>E-mail</th>
+      <th>Contrato</th>
+      <th>% por Aula</th>
+      <th>Ações</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let p of profissionais">
+      <td>{{ p.nome }}</td>
+      <td>{{ p.email }}</td>
+      <td>{{ tipoContratoLabel[p.tipoContrato] }}</td>
+      <td>{{ p.percentualPagamentoAula }}%</td>
+      <td class="acoes">
+        <a [routerLink]="['/profissionais', p.id]" class="btn btn-sm btn-outline">Ver</a>
+        <a [routerLink]="['/profissionais', p.id, 'editar']" class="btn btn-sm btn-secondary">Editar</a>
+        <button class="btn btn-sm btn-danger" (click)="confirmarInativar(p.id)">Inativar</button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="pagination" *ngIf="totalPages > 1">
+  <button *ngFor="let p of pages()" [class.active]="p === currentPage" (click)="pagina(p)">
+    {{ p + 1 }}
+  </button>
+</div>
+
+<div class="dialog-overlay" *ngIf="confirmarInativarId !== null">
+  <div class="dialog">
+    <p>Confirma a inativação do profissional?</p>
+    <div class="dialog-actions">
+      <button class="btn btn-danger" (click)="inativar()">Confirmar</button>
+      <button class="btn btn-outline" (click)="cancelarInativar()">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.scss
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.scss
@@ -1,0 +1,17 @@
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #4a0080;
+  }
+}
+
+.acoes {
+  display: flex;
+  gap: .5rem;
+}

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
@@ -1,0 +1,88 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+import { ProfissionalListComponent } from './profissional-list.component';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { ProfissionalPage, ProfissionalResponseDTO } from '../../../core/models/profissional';
+
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 1,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+const mockPage: ProfissionalPage = {
+  content: [mockProfissional],
+  totalElements: 1,
+  totalPages: 2,
+  size: 10,
+  number: 0
+};
+
+describe('ProfissionalListComponent', () => {
+  let component: ProfissionalListComponent;
+  let fixture: ComponentFixture<ProfissionalListComponent>;
+  let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ProfissionalService', ['listar', 'inativar']);
+    serviceSpy.listar.and.returnValue(of(mockPage));
+
+    await TestBed.configureTestingModule({
+      imports: [ProfissionalListComponent, RouterTestingModule],
+      providers: [{ provide: ProfissionalService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfissionalListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load profissionais on init', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(0, 10);
+    expect(component.profissionais).toEqual([mockProfissional]);
+    expect(component.totalPages).toBe(2);
+  });
+
+  it('should set erro when listar fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+    component.carregar();
+    expect(component.erro).toBe('Erro ao carregar profissionais.');
+  });
+
+  it('should set confirmarInativarId when confirmarInativar is called', () => {
+    component.confirmarInativar(1);
+    expect(component.confirmarInativarId).toBe(1);
+  });
+
+  it('should clear confirmarInativarId when cancelarInativar is called', () => {
+    component.confirmarInativarId = 1;
+    component.cancelarInativar();
+    expect(component.confirmarInativarId).toBeNull();
+  });
+
+  it('should call inativar and reload list on success', () => {
+    serviceSpy.inativar.and.returnValue(of(undefined));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(serviceSpy.inativar).toHaveBeenCalledWith(1);
+    expect(serviceSpy.listar).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set erro when inativar fails', () => {
+    serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
+    component.confirmarInativarId = 1;
+    component.inativar();
+    expect(component.erro).toBe('Erro ao inativar profissional.');
+  });
+});

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import { ProfissionalResponseDTO, TIPO_CONTRATO_LABEL } from '../../../core/models/profissional';
+
+@Component({
+  selector: 'app-profissional-list',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './profissional-list.component.html',
+  styleUrl: './profissional-list.component.scss'
+})
+export class ProfissionalListComponent implements OnInit {
+  profissionais: ProfissionalResponseDTO[] = [];
+  totalPages = 0;
+  currentPage = 0;
+  pageSize = 10;
+  loading = false;
+  erro: string | null = null;
+  confirmarInativarId: number | null = null;
+
+  readonly tipoContratoLabel = TIPO_CONTRATO_LABEL;
+
+  constructor(private service: ProfissionalService) {}
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading = true;
+    this.erro = null;
+    this.service.listar(this.currentPage, this.pageSize).subscribe({
+      next: page => {
+        this.profissionais = page.content;
+        this.totalPages = page.totalPages;
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar profissionais.';
+        this.loading = false;
+      }
+    });
+  }
+
+  confirmarInativar(id: number): void {
+    this.confirmarInativarId = id;
+  }
+
+  cancelarInativar(): void {
+    this.confirmarInativarId = null;
+  }
+
+  inativar(): void {
+    if (this.confirmarInativarId === null) return;
+
+    this.service.inativar(this.confirmarInativarId).subscribe({
+      next: () => {
+        this.confirmarInativarId = null;
+        this.carregar();
+      },
+      error: () => {
+        this.erro = 'Erro ao inativar profissional.';
+        this.confirmarInativarId = null;
+      }
+    });
+  }
+
+  pagina(p: number): void {
+    this.currentPage = p;
+    this.carregar();
+  }
+
+  pages(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -138,6 +138,7 @@ body {
   margin-bottom: 1rem;
 
   &-danger { background: #fdecea; color: #c62828; border: 1px solid #f5c6c6; }
+  &-warning { background: #fff8e1; color: #8d6e00; border: 1px solid #ffe082; }
 }
 
 /* Loading / empty */


### PR DESCRIPTION
## Summary
- align planos, pagamentos and aulas flows with the updated backend contract and new global routes
- add full frontend support for profissionais, including list, detail, create, edit, activate and deactivate flows
- update/add tests for the new services, components and route behavior

## Validation
- npm run build
- npm test -- --watch=false --browsers=ChromeHeadless