### PR TITLE
Add Docker setup for frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.angular
+.git
+.gitignore
+.codex
+coverage
+*.log
+docs/*.docx
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,9 @@ dist
 coverage
 *.log
 docs/*.docx
-
+.env
+.env.*
+Dockerfile
+docker-compose.yml
+.github
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:22-alpine3.21 AS build
 
 WORKDIR /app
 
@@ -8,12 +8,13 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:1.27-alpine
-
-ENV BACKEND_URL=http://host.docker.internal:8080
+FROM nginx:1.27-alpine3.21
 
 COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist/carlessopilatesfe/browser /usr/share/nginx/html
 
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost/ || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+ENV BACKEND_URL=http://host.docker.internal:8080
+
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build /app/dist/carlessopilatesfe/browser /usr/share/nginx/html
+
+EXPOSE 80
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A aplicação oferece um CRUD completo de pacientes com listagem paginada, formu
 - Node.js 18+
 - Angular CLI: `npm install -g @angular/cli`
 - Backend rodando em `http://localhost:8080`
+- Docker e Docker Compose, para execução em container
 
 ---
 
@@ -38,6 +39,35 @@ npm install
 
 ---
 
+## Docker
+
+A imagem Docker compila a aplicação Angular e serve os arquivos estáticos com Nginx. O Nginx também redireciona `/api/*` para o backend configurado por `BACKEND_URL`.
+
+```bash
+# Backend local em http://localhost:8080
+docker compose up --build
+```
+
+A aplicação fica disponível em `http://localhost:4200`.
+
+Para apontar para outro backend:
+
+```bash
+BACKEND_URL=http://api:8080 docker compose up --build
+```
+
+Também é possível construir e executar sem Compose:
+
+```bash
+docker build -t carlessopilatesfe .
+docker run --rm -p 4200:80 \
+  -e BACKEND_URL=http://host.docker.internal:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  carlessopilatesfe
+```
+
+---
+
 ## Stack
 
 | Camada     | Tecnologia                    |
@@ -48,6 +78,7 @@ npm install
 | Forms      | Reactive Forms                |
 | HTTP       | HttpClient + proxy `/api/*`   |
 | Testes     | Karma + Jasmine               |
+| Container  | Docker + Nginx                |
 
 ---
 
@@ -120,3 +151,5 @@ Na tela de detalhe, o botão de ação muda conforme o status: **Inativar** para
 ## Proxy de desenvolvimento
 
 O Angular CLI redireciona `/api/*` → `http://localhost:8080/*` via `proxy.conf.json`, eliminando problemas de CORS em ambiente local.
+
+Em Docker, o proxy equivalente é feito pelo Nginx em `nginx/default.conf.template`, usando a variável `BACKEND_URL`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@ services:
   frontend:
     build:
       context: .
-    image: carlessopilatesfe:latest
+    image: carlessopilatesfe:dev
     ports:
       - "4200:80"
     environment:
       BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:8080}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  frontend:
+    build:
+      context: .
+    image: carlessopilatesfe:latest
+    ports:
+      - "4200:80"
+    environment:
+      BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:8080}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+

--- a/docs/context.md
+++ b/docs/context.md
@@ -19,8 +19,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 5. Implementação de testes unitários e atualização da documentação
 6. Alinhamento com API v2: PATCH ativar/inativar, e-mail mutável no PUT
 7. Implementação dos módulos de Planos, Pagamentos e Aulas
+8. Dockerização do frontend com build Angular multi-stage e Nginx
 
-A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. Ainda não há autenticação, outros módulos ou configuração de ambiente.
+A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 
@@ -44,7 +45,17 @@ Por regra de negócio, o CPF não pode ser alterado após o cadastro. O formulá
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.
 
-A configuração por `environment.ts` (para separar dev/prod) ainda é um próximo passo planejado.
+### Docker com Nginx
+A imagem Docker usa build multi-stage: `node:22-alpine` instala dependências e executa `npm run build`; `nginx:1.27-alpine` serve o conteúdo de `dist/carlessopilatesfe/browser`.
+
+O Nginx mantém o mesmo contrato de URL relativa do frontend:
+
+- `/` serve a SPA com fallback para `index.html`
+- `/api/*` é redirecionado para `${BACKEND_URL}/*`
+
+O valor padrão de `BACKEND_URL` é `http://host.docker.internal:8080`, adequado para backend rodando na máquina host durante desenvolvimento local com Docker Compose. Em ambientes integrados, a variável deve apontar para o serviço real da API.
+
+A configuração por `environment.ts` ainda não é necessária porque o frontend continua usando URLs relativas e o alvo da API é resolvido no proxy.
 
 ---
 
@@ -127,6 +138,7 @@ Erros são tratados no subscribe via callback de erro, exibindo mensagem genéri
 - Node.js 18+
 - Angular CLI (`npm install -g @angular/cli`)
 - Backend rodando em `http://localhost:8080`
+- Docker e Docker Compose, para execução em container
 
 ### Passos
 ```bash
@@ -137,6 +149,19 @@ npm install
 npm start
 
 # Acessar em http://localhost:4200
+```
+
+### Docker
+```bash
+# Backend local em http://localhost:8080
+docker compose up --build
+
+# Acessar em http://localhost:4200
+```
+
+Para outro backend:
+```bash
+BACKEND_URL=http://api:8080 docker compose up --build
 ```
 
 ---

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -23,6 +23,7 @@
 | Reatividade    | RxJS 7.8                                |
 | Testes         | Karma + Jasmine                         |
 | Build          | Angular CLI 19.2 / @angular-devkit      |
+| Container      | Docker + Nginx                          |
 
 ---
 
@@ -63,7 +64,11 @@ carlessopilatesfe/
 │   ├── main.ts                          # Ponto de entrada (bootstrap)
 │   └── index.html                       # HTML principal
 ├── docs/                                # Documentação do projeto
+├── nginx/
+│   └── default.conf.template            # Proxy /api e fallback da SPA em Docker
 ├── angular.json                         # Configuração do Angular CLI
+├── Dockerfile                           # Build multi-stage e imagem Nginx
+├── docker-compose.yml                   # Execução local em container
 ├── package.json                         # Dependências e scripts
 └── tsconfig.json                        # Configuração do TypeScript
 ```
@@ -146,7 +151,9 @@ interface Page<T> {
 Arquivo: `src/app/core/services/paciente.service.ts`  
 Injetável em toda a aplicação (`providedIn: 'root'`).
 
-**URL base:** `http://localhost:8080/pacientes`
+**URL base no frontend:** `/api/pacientes`
+
+Em desenvolvimento local, o Angular CLI redireciona `/api` para `http://localhost:8080` via `proxy.conf.json`. Em Docker, o Nginx redireciona `/api` para o valor de `BACKEND_URL`.
 
 | Método            | Endpoint HTTP               | Descrição                        |
 |-------------------|-----------------------------|----------------------------------|
@@ -259,6 +266,41 @@ npm test         # Execução dos testes unitários (Karma/Jasmine)
 
 ---
 
+## Docker
+
+O Dockerfile usa duas etapas:
+
+| Etapa | Imagem | Responsabilidade |
+|-------|--------|------------------|
+| `build` | `node:22-alpine` | Instalar dependências com `npm ci` e gerar `dist/carlessopilatesfe/browser` |
+| runtime | `nginx:1.27-alpine` | Servir a SPA e redirecionar `/api/*` para o backend |
+
+### Execução com Compose
+
+```bash
+docker compose up --build
+```
+
+A aplicação fica disponível em `http://localhost:4200`. Por padrão, `BACKEND_URL` aponta para `http://host.docker.internal:8080`.
+
+### Configurar backend
+
+```bash
+BACKEND_URL=http://api:8080 docker compose up --build
+```
+
+### Execução com Docker
+
+```bash
+docker build -t carlessopilatesfe .
+docker run --rm -p 4200:80 \
+  -e BACKEND_URL=http://host.docker.internal:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  carlessopilatesfe
+```
+
+---
+
 ## Testes Unitários
 
 Framework: **Karma + Jasmine**  
@@ -298,11 +340,12 @@ Comando: `npm test`
 - Módulo Pagamentos: listagem, criação e confirmação de pagamento (PAGO)
 - Módulo Aulas: listagem e confirmação de presença
 - Navegação contextual na tela de detalhe do paciente (Planos / Pagamentos / Aulas)
+- Dockerfile, Docker Compose e Nginx para execução do frontend em container
 - Testes unitários (serviço e todos os componentes de página)
 
 ### Não implementado / Próximos passos
 - Autenticação e autorização
-- Variável de ambiente para URL da API (atualmente hardcoded via proxy)
+- Configuração avançada de ambientes Angular, caso seja necessária no futuro
 - Componente `ConfirmarDialog` integrado
 - Testes E2E
 - Busca e filtros nas listagens

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -4,13 +4,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header Referrer-Policy no-referrer;
+
     location /api/ {
         proxy_pass ${BACKEND_URL}/;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+
+    location ~* \.(js|css|png|jpg|ico|woff2|woff|ttf|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
     }
 
     location / {

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass ${BACKEND_URL}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Resumo
- adiciona Dockerfile multi-stage para build Angular e runtime com Nginx
- adiciona docker-compose para execução local em `http://localhost:4200`
- configura proxy Nginx `/api/*` com `BACKEND_URL`
- atualiza README, documentação e contexto do projeto

## Validação
- `npm run build`
- `docker compose config`
- `npm test -- --watch=false --browsers=ChromeHeadless`

## Observação
- `docker build -t carlessopilatesfe:test .` não pôde ser executado neste ambiente porque o usuário atual não tem permissão de acesso ao Docker daemon (`/var/run/docker.sock`).