### PR TITLE
fix: usar PUT ao atualizar profissional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Interface web para gestão administrativa de um estúdio de pilates, desenvolvid
 
 ## Visão Geral
 
-A aplicação oferece um CRUD completo de pacientes com listagem paginada, formulário de cadastro/edição e visualização detalhada. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
+A aplicação oferece CRUDs administrativos para pacientes e profissionais, além de fluxos de planos, pagamentos e aulas. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
 
 **Documentação detalhada:** [`docs/documentacao.md`](docs/documentacao.md)  
 **Contexto e decisões técnicas:** [`docs/context.md`](docs/context.md)
@@ -87,12 +87,13 @@ docker run --rm -p 4200:80 \
 ```
 src/app/
 ├── core/
-│   ├── models/paciente.ts          # DTOs e interfaces
-│   └── services/paciente.service.ts # Integração com a API REST
+│   ├── models/                     # DTOs e interfaces
+│   └── services/                   # Integração com a API REST
 ├── pages/pacientes/
 │   ├── paciente-list/              # Listagem paginada
 │   ├── paciente-form/              # Cadastro e edição
 │   └── paciente-detail/            # Visualização detalhada
+├── pages/profissionais/            # CRUD de profissionais
 └── shared/components/              # Componentes reutilizáveis
 ```
 
@@ -109,9 +110,13 @@ npm test
 Arquivos de teste:
 - `src/app/app.component.spec.ts`
 - `src/app/core/services/paciente.service.spec.ts`
+- `src/app/core/services/profissional.service.spec.ts`
 - `src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts`
 - `src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts`
 - `src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts`
+- `src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts`
+- `src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts`
+- `src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts`
 
 ---
 
@@ -120,6 +125,7 @@ Arquivos de teste:
 | Módulo | Descrição |
 |--------|-----------|
 | **Pacientes** | CRUD completo com ativação/inativação |
+| **Profissionais** | CRUD completo com ativação/inativação e atualização via PUT |
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
 | **Aulas** | Visualização das aulas geradas e confirmação de presença |
@@ -135,16 +141,21 @@ Arquivos de teste:
 | `/pacientes/novo`       | Formulário de cadastro                      |
 | `/pacientes/:id`        | Detalhes do paciente (ativo ou inativo)     |
 | `/pacientes/:id/editar` | Formulário de edição                        |
+| `/profissionais`        | Lista de profissionais ativos (paginada)    |
+| `/profissionais/novo`   | Formulário de cadastro de profissional      |
+| `/profissionais/:id`    | Detalhes do profissional                    |
+| `/profissionais/:id/editar` | Formulário de edição de profissional    |
 
 Na tela de detalhe, o botão de ação muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
 
 | Caminho | Função |
 |---------|--------|
-| `/pacientes/:id/planos` | Lista de planos do paciente |
-| `/pacientes/:id/planos/novo` | Criar novo plano |
-| `/pacientes/:id/pagamentos` | Lista de pagamentos |
-| `/pacientes/:id/pagamentos/novo` | Registrar novo pagamento |
-| `/pacientes/:id/aulas` | Lista de aulas geradas |
+| `/planos/paciente/:pacienteId` | Lista de planos do paciente |
+| `/planos/novo/:pacienteId` | Criar novo plano |
+| `/pagamentos/paciente/:pacienteId` | Lista de pagamentos |
+| `/pagamentos/novo/:pacienteId` | Registrar novo pagamento |
+| `/aulas/paciente/:pacienteId` | Lista de aulas geradas |
+| `/aulas/pagamento/:pagamentoId` | Lista de aulas por pagamento |
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -130,7 +130,8 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 - `GET /pacientes/{id}` → `PacienteResponseDTO`
 - `POST /pacientes` (body: `PacienteRequestDTO`) → `PacienteResponseDTO`
 - `PUT /pacientes/{id}` (body: `PacienteUpdateDTO`) → `PacienteResponseDTO`
-- `DELETE /pacientes/{id}` → `204 No Content`
+- `PATCH /pacientes/{id}/inativar` → `204 No Content`
+- `PATCH /pacientes/{id}/ativar` → `204 No Content`
 - `GET /profissionais?page=0&size=10&sort=nome` → `Page<ProfissionalResponseDTO>`
 - `GET /profissionais/{id}` → `ProfissionalResponseDTO`
 - `POST /profissionais` (body: `ProfissionalRequestDTO`) → `ProfissionalResponseDTO`

--- a/docs/context.md
+++ b/docs/context.md
@@ -20,6 +20,7 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 6. Alinhamento com API v2: PATCH ativar/inativar, e-mail mutável no PUT
 7. Implementação dos módulos de Planos, Pagamentos e Aulas
 8. Dockerização do frontend com build Angular multi-stage e Nginx
+9. Correção da atualização de profissionais para `PUT /profissionais/{id}`
 
 A funcionalidade central de **gestão de pacientes** está operacional, com cobertura de testes unitários para o serviço e todos os componentes de página. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
@@ -41,6 +42,9 @@ O backend não remove pacientes fisicamente. Inativação usa `PATCH /pacientes/
 
 ### CPF imutável após cadastro
 Por regra de negócio, o CPF não pode ser alterado após o cadastro. O formulário de edição desabilita apenas o campo CPF. O e-mail pode ser atualizado via `PUT /pacientes/{id}` e é incluído no `PacienteUpdateDTO`.
+
+### Atualização de profissionais via PUT
+O cadastro de profissionais segue o contrato do backend para atualização via `PUT /profissionais/{id}` com `ProfissionalUpdateDTO`. Ativação e inativação continuam usando endpoints específicos com `PATCH`.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.
@@ -127,6 +131,12 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 - `POST /pacientes` (body: `PacienteRequestDTO`) → `PacienteResponseDTO`
 - `PUT /pacientes/{id}` (body: `PacienteUpdateDTO`) → `PacienteResponseDTO`
 - `DELETE /pacientes/{id}` → `204 No Content`
+- `GET /profissionais?page=0&size=10&sort=nome` → `Page<ProfissionalResponseDTO>`
+- `GET /profissionais/{id}` → `ProfissionalResponseDTO`
+- `POST /profissionais` (body: `ProfissionalRequestDTO`) → `ProfissionalResponseDTO`
+- `PUT /profissionais/{id}` (body: `ProfissionalUpdateDTO`) → `ProfissionalResponseDTO`
+- `PATCH /profissionais/{id}/ativar` → `204 No Content`
+- `PATCH /profissionais/{id}/inativar` → `204 No Content`
 
 Erros são tratados no subscribe via callback de erro, exibindo mensagem genérica ao usuário.
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -149,6 +149,36 @@ interface Page<T> {
 
 Arquivo: `src/app/core/models/profissional.ts`
 
+### `ProfissionalResponseDTO`
+Retorno da API ao listar/buscar profissionais.
+```typescript
+interface ProfissionalResponseDTO {
+  id: number;
+  nome: string;
+  email: string;
+  cpf: string;
+  telefone: string | null;
+  tipoContrato: 'CLT' | 'PJ' | 'AUTONOMO';
+  percentualPagamentoAula: number;
+  dataInicio: string;
+  ativo: boolean;
+}
+```
+
+### `ProfissionalRequestDTO`
+Payload para criação de profissional.
+```typescript
+interface ProfissionalRequestDTO {
+  nome: string;
+  email: string;
+  cpf: string;
+  telefone?: string;
+  tipoContrato: 'CLT' | 'PJ' | 'AUTONOMO';
+  percentualPagamentoAula: number;
+  dataInicio: string;
+}
+```
+
 ### `ProfissionalUpdateDTO`
 Payload para atualização de profissionais via `PUT /profissionais/{id}`.
 ```typescript

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -5,7 +5,7 @@
 **Projeto:** Carlesso Pilates Frontend  
 **Versão:** 0.0.0  
 **Tecnologia:** Angular 19 (SPA)  
-**Propósito:** Interface web para gestão de pacientes de um estúdio de pilates.  
+**Propósito:** Interface web para gestão administrativa de um estúdio de pilates.
 **Backend esperado:** API REST em `http://localhost:8080`
 
 ---
@@ -32,9 +32,10 @@
 | Módulo | Rotas | Funcionalidades |
 |--------|-------|-----------------|
 | Pacientes | `/pacientes`, `/pacientes/:id`, `/pacientes/novo`, `/pacientes/:id/editar` | CRUD completo, ativar/inativar |
-| Planos | `/pacientes/:id/planos`, `/pacientes/:id/planos/novo` | Listar, criar (com seleção de dias e validação de frequência), inativar |
-| Pagamentos | `/pacientes/:id/pagamentos`, `/pacientes/:id/pagamentos/novo` | Listar, criar, confirmar pagamento |
-| Aulas | `/pacientes/:id/aulas` | Listar, confirmar presença |
+| Profissionais | `/profissionais`, `/profissionais/:id`, `/profissionais/novo`, `/profissionais/:id/editar` | CRUD completo, ativar/inativar, atualização via PUT |
+| Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
+| Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
+| Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença |
 
 ---
 
@@ -46,14 +47,17 @@ carlessopilatesfe/
 │   ├── app/
 │   │   ├── core/
 │   │   │   ├── models/
-│   │   │   │   └── paciente.ts          # DTOs e interfaces de dados
+│   │   │   │   ├── paciente.ts          # DTOs e interfaces de pacientes
+│   │   │   │   └── profissional.ts      # DTOs e interfaces de profissionais
 │   │   │   └── services/
-│   │   │       └── paciente.service.ts  # Serviço de integração com a API
+│   │   │       ├── paciente.service.ts  # Serviço de integração com a API de pacientes
+│   │   │       └── profissional.service.ts # Serviço de integração com a API de profissionais
 │   │   ├── pages/
-│   │   │   └── pacientes/
-│   │   │       ├── paciente-list/       # Listagem paginada de pacientes
-│   │   │       ├── paciente-form/       # Formulário de cadastro e edição
-│   │   │       └── paciente-detail/     # Visualização detalhada
+│   │   │   ├── pacientes/
+│   │   │   │   ├── paciente-list/       # Listagem paginada de pacientes
+│   │   │   │   ├── paciente-form/       # Formulário de cadastro e edição
+│   │   │   │   └── paciente-detail/     # Visualização detalhada
+│   │   │   └── profissionais/           # CRUD de profissionais
 │   │   ├── shared/
 │   │   │   └── components/
 │   │   │       └── confirmar-dialog/    # Componente de diálogo reutilizável
@@ -143,6 +147,21 @@ interface Page<T> {
 }
 ```
 
+Arquivo: `src/app/core/models/profissional.ts`
+
+### `ProfissionalUpdateDTO`
+Payload para atualização de profissionais via `PUT /profissionais/{id}`.
+```typescript
+interface ProfissionalUpdateDTO {
+  nome?: string;
+  email?: string;
+  telefone?: string;
+  tipoContrato?: 'CLT' | 'PJ' | 'AUTONOMO';
+  percentualPagamentoAula?: number;
+  dataInicio?: string;
+}
+```
+
 ---
 
 ## Serviços
@@ -164,6 +183,21 @@ Em desenvolvimento local, o Angular CLI redireciona `/api` para `http://localhos
 | `ativar(id)`      | `PATCH /pacientes/{id}/ativar` | Reativa paciente inativo      |
 | `inativar(id)`    | `PATCH /pacientes/{id}/inativar` | Inativa paciente (soft delete) |
 
+### `ProfissionalService`
+Arquivo: `src/app/core/services/profissional.service.ts`
+Injetável em toda a aplicação (`providedIn: 'root'`).
+
+**URL base no frontend:** `/api/profissionais`
+
+| Método            | Endpoint HTTP               | Descrição                        |
+|-------------------|-----------------------------|----------------------------------|
+| `listar(page, size)` | `GET /profissionais?page&size&sort=nome` | Lista profissionais ativos paginados |
+| `buscar(id)`      | `GET /profissionais/{id}`       | Busca profissional por ID        |
+| `cadastrar(dto)`  | `POST /profissionais`           | Cria novo profissional           |
+| `atualizar(id, dto)` | `PUT /profissionais/{id}`    | Atualiza dados do profissional   |
+| `ativar(id)`      | `PATCH /profissionais/{id}/ativar` | Reativa profissional inativo  |
+| `inativar(id)`    | `PATCH /profissionais/{id}/inativar` | Inativa profissional          |
+
 ---
 
 ## Rotas
@@ -178,6 +212,10 @@ Todos os componentes são carregados com **lazy loading** via `loadComponent()`.
 | `/pacientes/novo`        | `PacienteFormComponent` | Formulário de cadastro         |
 | `/pacientes/:id`         | `PacienteDetailComponent` | Detalhes do paciente         |
 | `/pacientes/:id/editar`  | `PacienteFormComponent` | Formulário de edição           |
+| `/profissionais`         | `ProfissionalListComponent` | Lista de profissionais      |
+| `/profissionais/novo`    | `ProfissionalFormComponent` | Formulário de cadastro      |
+| `/profissionais/:id`     | `ProfissionalDetailComponent` | Detalhes do profissional  |
+| `/profissionais/:id/editar` | `ProfissionalFormComponent` | Formulário de edição     |
 
 ---
 
@@ -312,6 +350,7 @@ Comando: `npm test`
 |---------|-----------|
 | `app/app.component.spec.ts` | Renderização da navbar e router-outlet |
 | `app/core/services/paciente.service.spec.ts` | Todos os métodos HTTP (listar, buscar, cadastrar, atualizar, inativar) |
+| `app/core/services/profissional.service.spec.ts` | Métodos HTTP de profissionais, incluindo atualização via PUT |
 | `app/pages/pacientes/paciente-list/paciente-list.component.spec.ts` | Carregamento, paginação, inativação, estados de erro |
 | `app/pages/pacientes/paciente-form/paciente-form.component.spec.ts` | Modo criação e edição, validações, navegação, erros |
 | `app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts` | Carregamento, inativação, estados de erro |
@@ -329,6 +368,7 @@ Comando: `npm test`
 
 ### Implementado
 - CRUD completo de pacientes
+- CRUD completo de profissionais com atualização via PUT
 - Paginação server-side
 - Validação de formulários
 - Feedback de erros e loading

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -85,13 +85,13 @@ describe('ProfissionalService', () => {
     req.flush(mockProfissional);
   });
 
-  it('should PATCH /api/profissionais/:id', () => {
+  it('should PUT /api/profissionais/:id', () => {
     const dto: ProfissionalUpdateDTO = { nome: 'Paula Atualizada', percentualPagamentoAula: 50 };
 
     service.atualizar(1, dto).subscribe(item => expect(item).toEqual(mockProfissional));
 
     const req = httpMock.expectOne('/api/profissionais/1');
-    expect(req.request.method).toBe('PATCH');
+    expect(req.request.method).toBe('PUT');
     expect(req.request.body).toEqual(dto);
     req.flush(mockProfissional);
   });

--- a/src/app/core/services/profissional.service.ts
+++ b/src/app/core/services/profissional.service.ts
@@ -30,7 +30,7 @@ export class ProfissionalService {
   }
 
   atualizar(id: number, dto: ProfissionalUpdateDTO): Observable<ProfissionalResponseDTO> {
-    return this.http.patch<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`, dto);
+    return this.http.put<ProfissionalResponseDTO>(`${this.apiUrl}/${id}`, dto);
   }
 
   ativar(id: number): Observable<void> {


### PR DESCRIPTION
## Resumo
- Altera `ProfissionalService.atualizar` para usar `PUT /api/profissionais/{id}`.
- Atualiza o teste unitário do serviço para validar o método HTTP correto.
- Atualiza README e documentação com o contrato de profissionais e rotas atuais.

## Validação
- `npm test -- --watch=false --browsers=ChromeHeadless` (`135 SUCCESS`)
- `npm run build`

Closes #7