### PR TITLE
feat: adiciona paginação na consulta de pacientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Arquivos de teste:
 
 | Módulo | Descrição |
 |--------|-----------|
-| **Pacientes** | CRUD completo com ativação/inativação e filtros por nome, e-mail, CPF, telefone e status |
+| **Pacientes** | CRUD completo com ativação/inativação, filtros por nome, e-mail, CPF, telefone e status, e paginação com tamanho configurável |
 | **Profissionais** | CRUD completo com ativação/inativação e atualização via PUT |
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
@@ -146,7 +146,7 @@ Arquivos de teste:
 | `/profissionais/:id`    | Detalhes do profissional                    |
 | `/profissionais/:id/editar` | Formulário de edição de profissional    |
 
-Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API. O status padrão é **Ativos**, e a ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
+Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API junto de `page`, `size` e `sort=nome`. O status padrão é **Ativos**. A paginação exibe o intervalo atual, total de pacientes, navegação por página, botões anterior/próxima e seletor de itens por página. A ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
 
 | Caminho | Função |
 |---------|--------|

--- a/docs/context.md
+++ b/docs/context.md
@@ -184,5 +184,4 @@ BACKEND_URL=http://api:8080 docker compose up --build
 
 - **Repositório:** `carlessopilatesfe`
 - **Branch principal:** `master`
-- **Branch atual de desenvolvimento:** `feat/issue-11-paginacao-pacientes`
 - **Autor:** Fabio Carlesso

--- a/docs/context.md
+++ b/docs/context.md
@@ -22,8 +22,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 8. Dockerização do frontend com build Angular multi-stage e Nginx
 9. Correção da atualização de profissionais para `PUT /profissionais/{id}`
 10. Implementação de filtros na listagem de pacientes por nome, e-mail, CPF, telefone e status
+11. Implementação de paginação completa na consulta de pacientes, com resumo de registros, tamanho de página configurável e navegação anterior/próxima
 
-A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
+A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 
@@ -182,6 +183,6 @@ BACKEND_URL=http://api:8080 docker compose up --build
 ## Informações do Repositório
 
 - **Repositório:** `carlessopilatesfe`
-- **Branch principal:** `main`
-- **Branch atual de desenvolvimento:** `master`
+- **Branch principal:** `master`
+- **Branch atual de desenvolvimento:** `feat/issue-11-paginacao-pacientes`
 - **Autor:** Fabio Carlesso

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -31,7 +31,7 @@
 
 | Módulo | Rotas | Funcionalidades |
 |--------|-------|-----------------|
-| Pacientes | `/pacientes`, `/pacientes/:id`, `/pacientes/novo`, `/pacientes/:id/editar` | CRUD completo, filtros de busca, ativar/inativar |
+| Pacientes | `/pacientes`, `/pacientes/:id`, `/pacientes/novo`, `/pacientes/:id/editar` | CRUD completo, filtros de busca, paginação, ativar/inativar |
 | Profissionais | `/profissionais`, `/profissionais/:id`, `/profissionais/novo`, `/profissionais/:id/editar` | CRUD completo, ativar/inativar, atualização via PUT |
 | Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
 | Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
@@ -258,6 +258,9 @@ Todos os componentes são carregados com **lazy loading** via `loadComponent()`.
 ### `PacienteListComponent`
 - Tabela paginada de pacientes
 - Filtros por nome, e-mail, CPF, telefone e status (ativos/inativos)
+- Resumo do intervalo exibido e total de pacientes retornados pela API
+- Seletor de itens por página com opções 5, 10, 20 e 50
+- Navegação por página com botões anterior/próxima e janela de até 5 páginas visíveis
 - Colunas: Nome, E-mail, CPF, Telefone, Status, Ações
 - Ações: Ver, Editar, Inativar para ativos e Ativar para inativos
 - Diálogo de confirmação inline para ativação e inativação
@@ -382,7 +385,7 @@ Comando: `npm test`
 | `app/app.component.spec.ts` | Renderização da navbar e router-outlet |
 | `app/core/services/paciente.service.spec.ts` | Todos os métodos HTTP e parâmetros de filtro em `listar` |
 | `app/core/services/profissional.service.spec.ts` | Métodos HTTP de profissionais, incluindo atualização via PUT |
-| `app/pages/pacientes/paciente-list/paciente-list.component.spec.ts` | Carregamento, filtros, paginação, inativação, estados de erro |
+| `app/pages/pacientes/paciente-list/paciente-list.component.spec.ts` | Carregamento, filtros, paginação, troca de tamanho de página, inativação, estados de erro |
 | `app/pages/pacientes/paciente-form/paciente-form.component.spec.ts` | Modo criação e edição, validações, navegação, erros |
 | `app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts` | Carregamento, inativação, estados de erro |
 
@@ -400,6 +403,7 @@ Comando: `npm test`
 ### Implementado
 - CRUD completo de pacientes
 - Filtros na listagem de pacientes por nome, e-mail, CPF, telefone e status
+- Paginação da consulta de pacientes com resumo, navegação anterior/próxima, janela de páginas e tamanho de página configurável
 - CRUD completo de profissionais com atualização via PUT
 - Paginação server-side
 - Validação de formulários

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.html
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.html
@@ -47,42 +47,62 @@
   Nenhum paciente encontrado.
 </div>
 
-<table *ngIf="pacientes.length > 0" class="table">
-  <thead>
-    <tr>
-      <th>Nome</th>
-      <th>E-mail</th>
-      <th>CPF</th>
-      <th>Telefone</th>
-      <th>Status</th>
-      <th>Ações</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let p of pacientes">
-      <td>{{ p.nome }}</td>
-      <td>{{ p.email }}</td>
-      <td>{{ p.cpf }}</td>
-      <td>{{ p.telefone || '-' }}</td>
-      <td>
-        <span class="status-badge" [class.inactive]="!p.ativo">
-          {{ p.ativo ? 'Ativo' : 'Inativo' }}
-        </span>
-      </td>
-      <td class="acoes">
-        <a [routerLink]="['/pacientes', p.id]" class="btn btn-sm btn-outline">Ver</a>
-        <a [routerLink]="['/pacientes', p.id, 'editar']" class="btn btn-sm btn-secondary">Editar</a>
-        <button *ngIf="p.ativo" class="btn btn-sm btn-danger" (click)="confirmarInativar(p.id)">Inativar</button>
-        <button *ngIf="!p.ativo" class="btn btn-sm btn-primary" (click)="confirmarAtivar(p.id)">Ativar</button>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<ng-container *ngIf="pacientes.length > 0">
+  <div class="pagination-summary">
+    <span>Exibindo {{ pageStart() }}-{{ pageEnd() }} de {{ totalElements }} pacientes</span>
+
+    <label>
+      Itens por página
+      <select #pageSizeSelect [value]="pageSize" (change)="alterarTamanhoPagina(pageSizeSelect.value)">
+        <option *ngFor="let size of pageSizeOptions" [value]="size">{{ size }}</option>
+      </select>
+    </label>
+  </div>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>E-mail</th>
+        <th>CPF</th>
+        <th>Telefone</th>
+        <th>Status</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let p of pacientes">
+        <td>{{ p.nome }}</td>
+        <td>{{ p.email }}</td>
+        <td>{{ p.cpf }}</td>
+        <td>{{ p.telefone || '-' }}</td>
+        <td>
+          <span class="status-badge" [class.inactive]="!p.ativo">
+            {{ p.ativo ? 'Ativo' : 'Inativo' }}
+          </span>
+        </td>
+        <td class="acoes">
+          <a [routerLink]="['/pacientes', p.id]" class="btn btn-sm btn-outline">Ver</a>
+          <a [routerLink]="['/pacientes', p.id, 'editar']" class="btn btn-sm btn-secondary">Editar</a>
+          <button *ngIf="p.ativo" class="btn btn-sm btn-danger" (click)="confirmarInativar(p.id)">Inativar</button>
+          <button *ngIf="!p.ativo" class="btn btn-sm btn-primary" (click)="confirmarAtivar(p.id)">Ativar</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</ng-container>
 
 <div class="pagination" *ngIf="totalPages > 1">
-  <button *ngFor="let p of pages()" [class.active]="p === currentPage" (click)="pagina(p)">
+  <button type="button" [disabled]="!canGoPrevious()" (click)="paginaAnterior()">Anterior</button>
+  <button
+    type="button"
+    *ngFor="let p of pages()"
+    [class.active]="p === currentPage"
+    [attr.aria-current]="p === currentPage ? 'page' : null"
+    (click)="pagina(p)">
     {{ p + 1 }}
   </button>
+  <button type="button" [disabled]="!canGoNext()" (click)="proximaPagina()">Próxima</button>
 </div>
 
 <div class="dialog-overlay" *ngIf="confirmarAtivarId !== null">

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.html
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.html
@@ -90,20 +90,20 @@
       </tr>
     </tbody>
   </table>
-</ng-container>
 
-<div class="pagination" *ngIf="totalPages > 1">
-  <button type="button" [disabled]="!canGoPrevious()" (click)="paginaAnterior()">Anterior</button>
-  <button
-    type="button"
-    *ngFor="let p of pages()"
-    [class.active]="p === currentPage"
-    [attr.aria-current]="p === currentPage ? 'page' : null"
-    (click)="pagina(p)">
-    {{ p + 1 }}
-  </button>
-  <button type="button" [disabled]="!canGoNext()" (click)="proximaPagina()">Próxima</button>
-</div>
+  <div class="pagination" *ngIf="totalPages > 1">
+    <button type="button" [disabled]="!canGoPrevious()" (click)="paginaAnterior()">Anterior</button>
+    <button
+      type="button"
+      *ngFor="let p of pages()"
+      [class.active]="p === currentPage"
+      [attr.aria-current]="p === currentPage ? 'page' : null"
+      (click)="pagina(p)">
+      {{ p + 1 }}
+    </button>
+    <button type="button" [disabled]="!canGoNext()" (click)="proximaPagina()">Próxima</button>
+  </div>
+</ng-container>
 
 <div class="dialog-overlay" *ngIf="confirmarAtivarId !== null">
   <div class="dialog">

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
@@ -92,6 +92,33 @@
 
 .loading, .empty-state { text-align: center; color: #888; margin: 3rem 0; }
 
+.pagination-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: .75rem;
+  color: #555;
+  font-size: .9rem;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    color: #4a0080;
+    font-weight: 600;
+  }
+
+  select {
+    min-height: 34px;
+    border: 1px solid #d9c2e8;
+    border-radius: 4px;
+    padding: .35rem .5rem;
+    color: #333;
+    font: inherit;
+  }
+}
+
 .pagination {
   display: flex;
   gap: .5rem;
@@ -107,6 +134,14 @@
     cursor: pointer;
     &.active { background: #6a0dad; color: #fff; }
     &:hover:not(.active) { background: #f5e8ff; }
+    &:disabled { opacity: .5; cursor: not-allowed; }
+  }
+}
+
+@media (max-width: 640px) {
+  .pagination-summary {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
@@ -18,7 +18,7 @@ const mockPaciente: PacienteResponseDTO = {
 
 const mockPage: Page<PacienteResponseDTO> = {
   content: [mockPaciente],
-  totalElements: 1,
+  totalElements: 21,
   totalPages: 3,
   size: 10,
   number: 0
@@ -31,7 +31,11 @@ describe('PacienteListComponent', () => {
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('PacienteService', ['listar', 'inativar', 'ativar']);
-    serviceSpy.listar.and.returnValue(of(mockPage));
+    serviceSpy.listar.and.callFake((page = 0, size = 10) => of({
+      ...mockPage,
+      number: page,
+      size
+    }));
 
     await TestBed.configureTestingModule({
       imports: [PacienteListComponent, RouterTestingModule],
@@ -59,7 +63,10 @@ describe('PacienteListComponent', () => {
 
   it('should populate pacientes and totalPages on success', () => {
     expect(component.pacientes).toEqual([mockPaciente]);
+    expect(component.totalElements).toBe(21);
     expect(component.totalPages).toBe(3);
+    expect(component.currentPage).toBe(0);
+    expect(component.pageSize).toBe(10);
     expect(component.loading).toBeFalse();
     expect(component.erro).toBeNull();
   });
@@ -151,6 +158,109 @@ describe('PacienteListComponent', () => {
     });
   });
 
+  it('should ignore invalid or current page when pagina is called', () => {
+    serviceSpy.listar.calls.reset();
+    component.totalPages = 3;
+    component.currentPage = 1;
+
+    component.pagina(-1);
+    component.pagina(1);
+    component.pagina(3);
+
+    expect(component.currentPage).toBe(1);
+    expect(serviceSpy.listar).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to previous and next pages', () => {
+    serviceSpy.listar.calls.reset();
+    component.totalPages = 3;
+    component.currentPage = 1;
+
+    component.paginaAnterior();
+    expect(component.currentPage).toBe(0);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(0, 10, {
+      nome: '',
+      email: '',
+      cpf: '',
+      telefone: '',
+      ativo: true
+    });
+
+    component.proximaPagina();
+    expect(component.currentPage).toBe(1);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(1, 10, {
+      nome: '',
+      email: '',
+      cpf: '',
+      telefone: '',
+      ativo: true
+    });
+  });
+
+  it('should reset to first page and reload when page size changes', () => {
+    component.currentPage = 2;
+
+    component.alterarTamanhoPagina('20');
+
+    expect(component.pageSize).toBe(20);
+    expect(component.currentPage).toBe(0);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(0, 20, {
+      nome: '',
+      email: '',
+      cpf: '',
+      telefone: '',
+      ativo: true
+    });
+  });
+
+  it('should ignore unsupported or unchanged page size', () => {
+    serviceSpy.listar.calls.reset();
+
+    component.alterarTamanhoPagina('10');
+    component.alterarTamanhoPagina('15');
+
+    expect(component.pageSize).toBe(10);
+    expect(serviceSpy.listar).not.toHaveBeenCalled();
+  });
+
+  it('should reload previous page when current page is outside API result range', () => {
+    serviceSpy.listar.and.returnValues(
+      of({
+        content: [],
+        totalElements: 20,
+        totalPages: 2,
+        size: 10,
+        number: 2
+      }),
+      of({
+        content: [mockPaciente],
+        totalElements: 20,
+        totalPages: 2,
+        size: 10,
+        number: 1
+      })
+    );
+    component.currentPage = 2;
+
+    component.carregar();
+
+    expect(component.currentPage).toBe(1);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(2, 10, {
+      nome: '',
+      email: '',
+      cpf: '',
+      telefone: '',
+      ativo: true
+    });
+    expect(serviceSpy.listar).toHaveBeenCalledWith(1, 10, {
+      nome: '',
+      email: '',
+      cpf: '',
+      telefone: '',
+      ativo: true
+    });
+  });
+
   it('should reset page and reload with trimmed filters when buscar is called', () => {
     component.currentPage = 2;
     component.filtro = {
@@ -222,8 +332,44 @@ describe('PacienteListComponent', () => {
     expect(component.pages()).toEqual([0, 1, 2]);
   });
 
+  it('should return a sliding window of page indices from pages()', () => {
+    component.totalPages = 10;
+
+    component.currentPage = 0;
+    expect(component.pages()).toEqual([0, 1, 2, 3, 4]);
+
+    component.currentPage = 4;
+    expect(component.pages()).toEqual([2, 3, 4, 5, 6]);
+
+    component.currentPage = 9;
+    expect(component.pages()).toEqual([5, 6, 7, 8, 9]);
+  });
+
   it('should return empty array from pages() when totalPages is 0', () => {
     component.totalPages = 0;
     expect(component.pages()).toEqual([]);
+  });
+
+  it('should expose pagination state helpers', () => {
+    component.totalElements = 21;
+    component.totalPages = 3;
+    component.pageSize = 10;
+    component.currentPage = 0;
+
+    expect(component.canGoPrevious()).toBeFalse();
+    expect(component.canGoNext()).toBeTrue();
+    expect(component.pageStart()).toBe(1);
+    expect(component.pageEnd()).toBe(10);
+
+    component.currentPage = 2;
+    expect(component.canGoPrevious()).toBeTrue();
+    expect(component.canGoNext()).toBeFalse();
+    expect(component.pageStart()).toBe(21);
+    expect(component.pageEnd()).toBe(21);
+  });
+
+  it('should return zero as pageStart when there are no elements', () => {
+    component.totalElements = 0;
+    expect(component.pageStart()).toBe(0);
   });
 });

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
@@ -26,6 +26,7 @@ export class PacienteListComponent implements OnInit {
   currentPage = 0;
   pageSize = 10;
   readonly pageSizeOptions = [5, 10, 20, 50];
+  readonly maxVisiblePages = 5;
   loading = false;
   erro: string | null = null;
   confirmarInativarId: number | null = null;
@@ -50,7 +51,7 @@ export class PacienteListComponent implements OnInit {
     this.service.listar(this.currentPage, this.pageSize, this.montarFiltro()).subscribe({
       next: page => {
         if (page.totalPages > 0 && this.currentPage >= page.totalPages) {
-          this.currentPage = page.totalPages - 1;
+          this.currentPage = Math.max(0, page.totalPages - 1);
           this.carregar();
           return;
         }
@@ -166,13 +167,12 @@ export class PacienteListComponent implements OnInit {
   }
 
   pages(): number[] {
-    const visiblePages = 5;
-    if (this.totalPages <= visiblePages) {
+    if (this.totalPages <= this.maxVisiblePages) {
       return Array.from({ length: this.totalPages }, (_, i) => i);
     }
 
-    const start = Math.max(0, Math.min(this.currentPage - 2, this.totalPages - visiblePages));
-    return Array.from({ length: visiblePages }, (_, i) => start + i);
+    const start = Math.max(0, Math.min(this.currentPage - 2, this.totalPages - this.maxVisiblePages));
+    return Array.from({ length: this.maxVisiblePages }, (_, i) => start + i);
   }
 
   canGoPrevious(): boolean {
@@ -189,6 +189,7 @@ export class PacienteListComponent implements OnInit {
   }
 
   pageEnd(): number {
+    if (this.totalElements === 0) return 0;
     return Math.min((this.currentPage + 1) * this.pageSize, this.totalElements);
   }
 }

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
@@ -21,9 +21,11 @@ interface FiltroUI {
 })
 export class PacienteListComponent implements OnInit {
   pacientes: PacienteResponseDTO[] = [];
+  totalElements = 0;
   totalPages = 0;
   currentPage = 0;
   pageSize = 10;
+  readonly pageSizeOptions = [5, 10, 20, 50];
   loading = false;
   erro: string | null = null;
   confirmarInativarId: number | null = null;
@@ -47,8 +49,17 @@ export class PacienteListComponent implements OnInit {
     this.erro = null;
     this.service.listar(this.currentPage, this.pageSize, this.montarFiltro()).subscribe({
       next: page => {
+        if (page.totalPages > 0 && this.currentPage >= page.totalPages) {
+          this.currentPage = page.totalPages - 1;
+          this.carregar();
+          return;
+        }
+
         this.pacientes = page.content;
+        this.totalElements = page.totalElements;
         this.totalPages = page.totalPages;
+        this.currentPage = page.number;
+        this.pageSize = page.size;
         this.loading = false;
       },
       error: () => {
@@ -132,11 +143,52 @@ export class PacienteListComponent implements OnInit {
   }
 
   pagina(p: number): void {
+    if (p < 0 || p >= this.totalPages || p === this.currentPage) return;
     this.currentPage = p;
     this.carregar();
   }
 
+  paginaAnterior(): void {
+    this.pagina(this.currentPage - 1);
+  }
+
+  proximaPagina(): void {
+    this.pagina(this.currentPage + 1);
+  }
+
+  alterarTamanhoPagina(size: string): void {
+    const novoTamanho = Number(size);
+    if (!this.pageSizeOptions.includes(novoTamanho) || novoTamanho === this.pageSize) return;
+
+    this.pageSize = novoTamanho;
+    this.currentPage = 0;
+    this.carregar();
+  }
+
   pages(): number[] {
-    return Array.from({ length: this.totalPages }, (_, i) => i);
+    const visiblePages = 5;
+    if (this.totalPages <= visiblePages) {
+      return Array.from({ length: this.totalPages }, (_, i) => i);
+    }
+
+    const start = Math.max(0, Math.min(this.currentPage - 2, this.totalPages - visiblePages));
+    return Array.from({ length: visiblePages }, (_, i) => start + i);
+  }
+
+  canGoPrevious(): boolean {
+    return this.currentPage > 0;
+  }
+
+  canGoNext(): boolean {
+    return this.currentPage < this.totalPages - 1;
+  }
+
+  pageStart(): number {
+    if (this.totalElements === 0) return 0;
+    return this.currentPage * this.pageSize + 1;
+  }
+
+  pageEnd(): number {
+    return Math.min((this.currentPage + 1) * this.pageSize, this.totalElements);
   }
 }


### PR DESCRIPTION
## Resumo
- adiciona resumo de registros, botões anterior/próxima e janela de páginas na listagem de pacientes
- adiciona seletor de tamanho de página com opções 5, 10, 20 e 50
- trata página atual fora do intervalo quando o total de páginas muda
- atualiza README e documentação da funcionalidade

## Testes
- `npm test -- --watch=false --browsers=ChromeHeadless`
- `npm run build`

Closes #11