### PR TITLE
fix: valida parâmetros numéricos de rota

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf
 
 Na listagem de profissionais, a paginação server-side renderiza no máximo 5 botões de página por vez, evitando excesso de elementos no DOM em datasets grandes.
 
+As rotas que recebem identificadores numéricos validam os parâmetros antes de chamar a API. URLs com identificadores ausentes ou não numéricos exibem a mensagem **Identificador inválido.** e não disparam requisições com `NaN` no caminho.
+
 | Caminho | Função |
 |---------|--------|
 | `/planos/paciente/:pacienteId` | Lista de planos do paciente |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf
 
 Na listagem de profissionais, a paginação server-side renderiza no máximo 5 botões de página por vez, evitando excesso de elementos no DOM em datasets grandes.
 
-As rotas que recebem identificadores numéricos validam os parâmetros antes de chamar a API. URLs com identificadores ausentes ou não numéricos exibem a mensagem **Identificador inválido.** e não disparam requisições com `NaN` no caminho.
+As rotas que recebem identificadores numéricos validam os parâmetros antes de chamar a API. Apenas inteiros positivos seguros são aceitos; URLs com identificadores ausentes, não numéricos ou em formato inválido exibem a mensagem **Identificador inválido.** e não disparam requisições com `NaN` no caminho.
 
 | Caminho | Função |
 |---------|--------|

--- a/docs/context.md
+++ b/docs/context.md
@@ -146,7 +146,7 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 
 Erros são tratados no subscribe via callback de erro, exibindo mensagem genérica ao usuário.
 
-Rotas com parâmetros numéricos, como `pacienteId` e `pagamentoId`, usam validação explícita antes de acionar serviços. Quando o parâmetro está ausente ou não pode ser convertido para número, a tela exibe **Identificador inválido.** e interrompe o carregamento para não gerar URLs de API contendo `NaN`.
+Rotas com parâmetros numéricos, como `id`, `pacienteId` e `pagamentoId`, usam validação explícita antes de acionar serviços. Apenas inteiros positivos seguros são aceitos. Quando o parâmetro está ausente ou em formato inválido, a tela exibe **Identificador inválido.** e interrompe o carregamento para não gerar URLs de API contendo `NaN`.
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -24,6 +24,7 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 10. Implementação de filtros na listagem de pacientes por nome, e-mail, CPF, telefone e status
 11. Implementação de paginação completa na consulta de pacientes, com resumo de registros, tamanho de página configurável e navegação anterior/próxima
 12. Correção da paginação de profissionais para renderizar uma janela máxima de 5 botões de página
+13. Validação de parâmetros numéricos de rota para evitar chamadas à API com `NaN`
 
 A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side e limita os botões visíveis a uma janela de 5 páginas para evitar excesso de elementos no DOM. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
@@ -144,6 +145,8 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 - `PATCH /profissionais/{id}/inativar` → `204 No Content`
 
 Erros são tratados no subscribe via callback de erro, exibindo mensagem genérica ao usuário.
+
+Rotas com parâmetros numéricos, como `pacienteId` e `pagamentoId`, usam validação explícita antes de acionar serviços. Quando o parâmetro está ausente ou não pode ser convertido para número, a tela exibe **Identificador inválido.** e interrompe o carregamento para não gerar URLs de API contendo `NaN`.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -235,6 +235,8 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 Arquivo: `src/app/app.routes.ts`  
 Todos os componentes são carregados com **lazy loading** via `loadComponent()`.
 
+Os parâmetros numéricos das rotas são validados antes de qualquer chamada à API. Identificadores ausentes ou não numéricos exibem **Identificador inválido.** e interrompem o carregamento da tela.
+
 | Caminho                  | Componente              | Função                         |
 |--------------------------|-------------------------|--------------------------------|
 | `/`                      | —                       | Redireciona para `/pacientes`  |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -235,7 +235,7 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 Arquivo: `src/app/app.routes.ts`  
 Todos os componentes são carregados com **lazy loading** via `loadComponent()`.
 
-Os parâmetros numéricos das rotas são validados antes de qualquer chamada à API. Identificadores ausentes ou não numéricos exibem **Identificador inválido.** e interrompem o carregamento da tela.
+Os parâmetros numéricos das rotas são validados antes de qualquer chamada à API. Apenas inteiros positivos seguros são aceitos; identificadores ausentes, não numéricos ou em formato inválido exibem **Identificador inválido.** e interrompem o carregamento da tela.
 
 | Caminho                  | Componente              | Função                         |
 |--------------------------|-------------------------|--------------------------------|

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { registerLocaleData } from '@angular/common';
 import localePt from '@angular/common/locales/pt';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { AulaListComponent } from './aula-list.component';
 import { AulaService } from '../../../core/services/aula.service';
@@ -113,5 +113,19 @@ describe('AulaListComponent', () => {
       component.ngOnInit();
       expect(component.erro).toBe('Erro ao carregar dados do pagamento.');
     });
+  });
+
+  it('should not load aulas when route param is invalid', () => {
+    const serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
+    const pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+    const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
+    const component = new AulaListComponent(serviceSpy, pagamentoServiceSpy, invalidRoute);
+
+    component.ngOnInit();
+
+    expect(component.erro).toBe('Identificador inválido.');
+    expect(serviceSpy.listarPorPaciente).not.toHaveBeenCalled();
+    expect(serviceSpy.listarPorPagamento).not.toHaveBeenCalled();
+    expect(pagamentoServiceSpy.buscar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AulaService } from '../../../core/services/aula.service';
 import { PagamentoService } from '../../../core/services/pagamento.service';
 import { AulaResponseDTO } from '../../../core/models/plano';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-aula-list',
@@ -26,12 +27,22 @@ export class AulaListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const pacienteId = this.route.snapshot.paramMap.get('pacienteId');
-    const pagamentoId = this.route.snapshot.paramMap.get('pagamentoId');
+    const rawPacienteId = this.route.snapshot.paramMap.get('pacienteId');
+    const rawPagamentoId = this.route.snapshot.paramMap.get('pagamentoId');
 
-    this.pacienteId = pacienteId ? +pacienteId : null;
-    this.pagamentoId = pagamentoId ? +pagamentoId : null;
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
+    this.pagamentoId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pagamentoId');
     this.titulo = this.pagamentoId !== null ? 'Aulas do Pagamento' : 'Aulas do Paciente';
+
+    if ((rawPacienteId !== null && this.pacienteId === null) || (rawPagamentoId !== null && this.pagamentoId === null)) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
+
+    if (this.pacienteId === null && this.pagamentoId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
 
     if (this.pagamentoId !== null) {
       this.pagamentoService.buscar(this.pagamentoId).subscribe({
@@ -49,6 +60,10 @@ export class AulaListComponent implements OnInit {
   }
 
   carregar(): void {
+    if (this.pacienteId === null && this.pagamentoId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.loading = true;
     this.erro = null;
     const request$ = this.pagamentoId !== null

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { PacienteDetailComponent } from './paciente-detail.component';
 import { PacienteService } from '../../../core/services/paciente.service';
@@ -120,5 +120,24 @@ describe('PacienteDetailComponent', () => {
       expect(component.erro).toBe('Paciente não encontrado.');
       expect(component.loading).toBeFalse();
     });
+  });
+
+  it('should not call buscar when id route param is invalid', () => {
+    serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'ativar', 'inativar']);
+
+    TestBed.configureTestingModule({
+      imports: [PacienteDetailComponent, RouterTestingModule],
+      providers: [
+        { provide: PacienteService, useValue: serviceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ id: 'abc' }) } } }
+      ]
+    });
+
+    fixture = TestBed.createComponent(PacienteDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.erro).toBe('Identificador inválido.');
+    expect(serviceSpy.buscar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/pacientes/paciente-detail/paciente-detail.component.ts
+++ b/src/app/pages/pacientes/paciente-detail/paciente-detail.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PacienteService } from '../../../core/services/paciente.service';
 import { PacienteResponseDTO } from '../../../core/models/paciente';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-paciente-detail',
@@ -24,10 +25,13 @@ export class PacienteDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const id = this.route.snapshot.paramMap.get('id');
-    if (!id) return;
+    const id = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
+    if (id === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.loading = true;
-    this.service.buscar(+id).subscribe({
+    this.service.buscar(id).subscribe({
       next: p => {
         this.paciente = p;
         this.loading = false;

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.html
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.html
@@ -6,7 +6,7 @@
 <div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
 <div *ngIf="loading" class="loading">Carregando...</div>
 
-<form *ngIf="!loading" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
+<form *ngIf="!loading && !parametroInvalido" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
   <h2 class="form-section-title">Dados Pessoais</h2>
 
   <div class="form-group">

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { PacienteFormComponent } from './paciente-form.component';
 import { PacienteService } from '../../../core/services/paciente.service';
@@ -172,6 +172,34 @@ describe('PacienteFormComponent', () => {
       component.ngOnInit();
       expect(component.erro).toBe('Erro ao carregar paciente.');
       expect(component.loading).toBeFalse();
+    });
+  });
+
+  describe('with invalid id in route', () => {
+    let component: PacienteFormComponent;
+    let fixture: ComponentFixture<PacienteFormComponent>;
+    let serviceSpy: jasmine.SpyObj<PacienteService>;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('PacienteService', ['buscar', 'cadastrar', 'atualizar']);
+
+      await TestBed.configureTestingModule({
+        imports: [PacienteFormComponent, RouterTestingModule],
+        providers: [
+          { provide: PacienteService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ id: 'abc' }) } } }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(PacienteFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should not load patient or enter edit mode', () => {
+      expect(component.erro).toBe('Identificador inválido.');
+      expect(component.isEdit).toBeFalse();
+      expect(serviceSpy.buscar).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.spec.ts
@@ -198,8 +198,27 @@ describe('PacienteFormComponent', () => {
 
     it('should not load patient or enter edit mode', () => {
       expect(component.erro).toBe('Identificador inválido.');
+      expect(component.parametroInvalido).toBeTrue();
       expect(component.isEdit).toBeFalse();
       expect(serviceSpy.buscar).not.toHaveBeenCalled();
+    });
+
+    it('should hide form when id route param is invalid', () => {
+      expect(fixture.nativeElement.querySelector('form')).toBeNull();
+    });
+
+    it('should not call cadastrar when saving with invalid route param', () => {
+      component.form.patchValue({
+        nome: 'Ana Silva',
+        email: 'ana@email.com',
+        cpf: '123.456.789-00'
+      });
+
+      component.salvar();
+
+      expect(component.erro).toBe('Identificador inválido.');
+      expect(serviceSpy.cadastrar).not.toHaveBeenCalled();
+      expect(serviceSpy.atualizar).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
@@ -18,6 +18,7 @@ export class PacienteFormComponent implements OnInit {
   loading = false;
   salvando = false;
   erro: string | null = null;
+  parametroInvalido = false;
 
   constructor(
     private fb: FormBuilder,
@@ -48,6 +49,7 @@ export class PacienteFormComponent implements OnInit {
 
     this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
     if (this.pacienteId === null) {
+      this.parametroInvalido = true;
       this.erro = 'Identificador inválido.';
       return;
     }
@@ -68,6 +70,10 @@ export class PacienteFormComponent implements OnInit {
   }
 
   salvar(): void {
+    if (this.parametroInvalido) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;

--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PacienteService } from '../../../core/services/paciente.service';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-paciente-form',
@@ -42,23 +43,28 @@ export class PacienteFormComponent implements OnInit {
       })
     });
 
-    const id = this.route.snapshot.paramMap.get('id');
-    if (id) {
-      this.isEdit = true;
-      this.pacienteId = +id;
-      this.loading = true;
-      this.service.buscar(this.pacienteId).subscribe({
-        next: p => {
-          this.form.patchValue(p);
-          this.form.get('cpf')?.disable();
-          this.loading = false;
-        },
-        error: () => {
-          this.erro = 'Erro ao carregar paciente.';
-          this.loading = false;
-        }
-      });
+    const rawId = this.route.snapshot.paramMap.get('id');
+    if (rawId === null) return;
+
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
     }
+
+    this.isEdit = true;
+    this.loading = true;
+    this.service.buscar(this.pacienteId).subscribe({
+      next: p => {
+        this.form.patchValue(p);
+        this.form.get('cpf')?.disable();
+        this.loading = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar paciente.';
+        this.loading = false;
+      }
+    });
   }
 
   salvar(): void {

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 import { PagamentoFormComponent } from './pagamento-form.component';
 import { PagamentoService } from '../../../core/services/pagamento.service';
@@ -117,5 +118,24 @@ describe('PagamentoFormComponent', () => {
 
     expect(component.erro).toBe('Erro ao registrar pagamento.');
     expect(component.salvando).toBeFalse();
+  });
+
+  it('should not load planos when pacienteId route param is invalid', () => {
+    const invalidPagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['criar']);
+    const invalidPlanoServiceSpy = jasmine.createSpyObj('PlanoService', ['listar']);
+    const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
+    const invalidRouterSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const invalidComponent = new PagamentoFormComponent(
+      TestBed.inject(FormBuilder),
+      invalidPagamentoServiceSpy,
+      invalidPlanoServiceSpy,
+      invalidRoute,
+      invalidRouterSpy
+    );
+
+    invalidComponent.ngOnInit();
+
+    expect(invalidComponent.erro).toBe('Identificador inválido.');
+    expect(invalidPlanoServiceSpy.listar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PagamentoService } from '../../../core/services/pagamento.service';
 import { PlanoService } from '../../../core/services/plano.service';
 import { PlanoResponseDTO, TIPO_LABEL } from '../../../core/models/plano';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-pagamento-form',
@@ -14,7 +15,7 @@ import { PlanoResponseDTO, TIPO_LABEL } from '../../../core/models/plano';
 })
 export class PagamentoFormComponent implements OnInit {
   form!: FormGroup;
-  pacienteId!: number;
+  pacienteId: number | null = null;
   planos: PlanoResponseDTO[] = [];
   salvando = false;
   carregando = false;
@@ -31,17 +32,25 @@ export class PagamentoFormComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
     this.form = this.fb.group({
       planoId: [null, Validators.required],
       valor: [null, [Validators.required, Validators.min(0.01)]],
       dataVencimento: ['', Validators.required],
       periodoInicio: ['', Validators.required]
     });
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.carregarPlanos();
   }
 
   carregarPlanos(): void {
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.carregando = true;
     this.planoService.listar(this.pacienteId).subscribe({
       next: planos => {
@@ -60,6 +69,10 @@ export class PagamentoFormComponent implements OnInit {
   }
 
   salvar(): void {
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 import { PagamentoListComponent } from './pagamento-list.component';
 import { PagamentoService } from '../../../core/services/pagamento.service';
@@ -82,5 +83,16 @@ describe('PagamentoListComponent', () => {
     component.pagarForm.setValue({ dataPagamento: '2026-05-05' });
     component.confirmarPagar();
     expect(component.erro).toBe('Erro ao confirmar pagamento.');
+  });
+
+  it('should not load pagamentos when pacienteId route param is invalid', () => {
+    const invalidServiceSpy = jasmine.createSpyObj('PagamentoService', ['listar', 'pagar']);
+    const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
+    const invalidComponent = new PagamentoListComponent(invalidServiceSpy, invalidRoute, TestBed.inject(FormBuilder));
+
+    invalidComponent.ngOnInit();
+
+    expect(invalidComponent.erro).toBe('Identificador inválido.');
+    expect(invalidServiceSpy.listar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angula
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { PagamentoService } from '../../../core/services/pagamento.service';
 import { PagamentoResponseDTO, StatusPagamento } from '../../../core/models/plano';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-pagamento-list',
@@ -12,7 +13,7 @@ import { PagamentoResponseDTO, StatusPagamento } from '../../../core/models/plan
   styleUrl: './pagamento-list.component.scss'
 })
 export class PagamentoListComponent implements OnInit {
-  pacienteId!: number;
+  pacienteId: number | null = null;
   pagamentos: PagamentoResponseDTO[] = [];
   loading = false;
   erro: string | null = null;
@@ -32,12 +33,20 @@ export class PagamentoListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
     this.pagarForm = this.fb.group({ dataPagamento: ['', Validators.required] });
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.carregar();
   }
 
   carregar(): void {
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.loading = true;
     this.erro = null;
     this.service.listar(this.pacienteId).subscribe({

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 import { PlanoFormComponent } from './plano-form.component';
 import { PlanoService } from '../../../core/services/plano.service';
@@ -100,5 +101,30 @@ describe('PlanoFormComponent', () => {
   it('should not call service when form is invalid', () => {
     component.salvar();
     expect(serviceSpy.criar).not.toHaveBeenCalled();
+  });
+
+  it('should not call criar when pacienteId route param is invalid', () => {
+    const invalidServiceSpy = jasmine.createSpyObj('PlanoService', ['criar']);
+    const invalidRouterSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
+    const invalidComponent = new PlanoFormComponent(
+      TestBed.inject(FormBuilder),
+      invalidServiceSpy,
+      invalidRoute,
+      invalidRouterSpy
+    );
+
+    invalidComponent.ngOnInit();
+    invalidComponent.form.setValue({
+      tipo: 'MENSAL',
+      valor: 250,
+      frequenciaSemanal: 'UMA_VEZ',
+      dataInicio: '2026-05-01',
+      diasSemana: ['MONDAY']
+    });
+    invalidComponent.salvar();
+
+    expect(invalidComponent.erro).toBe('Identificador inválido.');
+    expect(invalidServiceSpy.criar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/planos/plano-form/plano-form.component.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractContro
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PlanoService } from '../../../core/services/plano.service';
 import { DiaSemana, FREQUENCIA_DIAS, FrequenciaSemanal } from '../../../core/models/plano';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 function diasSemanaValidator(control: AbstractControl): ValidationErrors | null {
   const group = control.parent;
@@ -23,7 +24,7 @@ function diasSemanaValidator(control: AbstractControl): ValidationErrors | null 
 })
 export class PlanoFormComponent implements OnInit {
   form!: FormGroup;
-  pacienteId!: number;
+  pacienteId: number | null = null;
   salvando = false;
   erro: string | null = null;
 
@@ -40,7 +41,7 @@ export class PlanoFormComponent implements OnInit {
   constructor(private fb: FormBuilder, private service: PlanoService, private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
     this.form = this.fb.group({
       tipo: ['', Validators.required],
       valor: [null, [Validators.required, Validators.min(0.01)]],
@@ -51,6 +52,9 @@ export class PlanoFormComponent implements OnInit {
     this.form.get('frequenciaSemanal')?.valueChanges.subscribe(() => {
       this.form.get('diasSemana')?.updateValueAndValidity();
     });
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+    }
   }
 
   toggleDia(dia: DiaSemana): void {
@@ -73,6 +77,10 @@ export class PlanoFormComponent implements OnInit {
   }
 
   salvar(): void {
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;

--- a/src/app/pages/planos/plano-list/plano-list.component.spec.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { PlanoListComponent } from './plano-list.component';
 import { PlanoService } from '../../../core/services/plano.service';
@@ -78,5 +78,16 @@ describe('PlanoListComponent', () => {
   it('diasFormatados should join day labels', () => {
     const result = component.diasFormatados(mockPlano);
     expect(result).toBe('Segunda, Quarta');
+  });
+
+  it('should not load planos when pacienteId route param is invalid', () => {
+    const invalidServiceSpy = jasmine.createSpyObj('PlanoService', ['listar', 'inativar']);
+    const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
+    const invalidComponent = new PlanoListComponent(invalidServiceSpy, invalidRoute);
+
+    invalidComponent.ngOnInit();
+
+    expect(invalidComponent.erro).toBe('Identificador inválido.');
+    expect(invalidServiceSpy.listar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/planos/plano-list/plano-list.component.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { PlanoService } from '../../../core/services/plano.service';
 import { PlanoResponseDTO, TIPO_LABEL, FREQUENCIA_LABEL, DIAS_SEMANA_LABEL } from '../../../core/models/plano';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-plano-list',
@@ -11,7 +12,7 @@ import { PlanoResponseDTO, TIPO_LABEL, FREQUENCIA_LABEL, DIAS_SEMANA_LABEL } fro
   styleUrl: './plano-list.component.scss'
 })
 export class PlanoListComponent implements OnInit {
-  pacienteId!: number;
+  pacienteId: number | null = null;
   planos: PlanoResponseDTO[] = [];
   loading = false;
   erro: string | null = null;
@@ -24,11 +25,19 @@ export class PlanoListComponent implements OnInit {
   constructor(private service: PlanoService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    this.pacienteId = +this.route.snapshot.paramMap.get('pacienteId')!;
+    this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.carregar();
   }
 
   carregar(): void {
+    if (this.pacienteId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     this.loading = true;
     this.erro = null;
     this.service.listar(this.pacienteId).subscribe({

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { ProfissionalDetailComponent } from './profissional-detail.component';
 import { ProfissionalService } from '../../../core/services/profissional.service';
@@ -81,5 +81,25 @@ describe('ProfissionalDetailComponent', () => {
     serviceSpy.inativar.and.returnValue(throwError(() => new Error('fail')));
     component.inativar();
     expect(component.erro).toBe('Erro ao inativar profissional.');
+  });
+
+  it('should not call buscar when id route param is invalid', async () => {
+    const invalidServiceSpy = jasmine.createSpyObj('ProfissionalService', ['buscar', 'ativar', 'inativar']);
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ProfissionalDetailComponent, RouterTestingModule],
+      providers: [
+        { provide: ProfissionalService, useValue: invalidServiceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ id: 'abc' }) } } }
+      ]
+    }).compileComponents();
+
+    const invalidFixture = TestBed.createComponent(ProfissionalDetailComponent);
+    const invalidComponent = invalidFixture.componentInstance;
+    invalidFixture.detectChanges();
+
+    expect(invalidComponent.erro).toBe('Identificador inválido.');
+    expect(invalidServiceSpy.buscar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/profissionais/profissional-detail/profissional-detail.component.ts
+++ b/src/app/pages/profissionais/profissional-detail/profissional-detail.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProfissionalService } from '../../../core/services/profissional.service';
 import { ProfissionalResponseDTO, TIPO_CONTRATO_LABEL } from '../../../core/models/profissional';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-profissional-detail',
@@ -26,11 +27,14 @@ export class ProfissionalDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const id = this.route.snapshot.paramMap.get('id');
-    if (!id) return;
+    const id = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
+    if (id === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
 
     this.loading = true;
-    this.service.buscar(+id).subscribe({
+    this.service.buscar(id).subscribe({
       next: profissional => {
         this.profissional = profissional;
         this.loading = false;

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.html
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.html
@@ -6,7 +6,7 @@
 <div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
 <div *ngIf="loading" class="loading">Carregando...</div>
 
-<form *ngIf="!loading" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
+<form *ngIf="!loading && !parametroInvalido" [formGroup]="form" (ngSubmit)="salvar()" class="form-card">
   <h2 class="form-section-title">Dados do Profissional</h2>
 
   <div class="form-group">

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
@@ -174,8 +174,30 @@ describe('ProfissionalFormComponent', () => {
 
     it('should not load profissional or enter edit mode', () => {
       expect(component.erro).toBe('Identificador inválido.');
+      expect(component.parametroInvalido).toBeTrue();
       expect(component.isEdit).toBeFalse();
       expect(serviceSpy.buscar).not.toHaveBeenCalled();
+    });
+
+    it('should hide form when id route param is invalid', () => {
+      expect(fixture.nativeElement.querySelector('form')).toBeNull();
+    });
+
+    it('should not call cadastrar when saving with invalid route param', () => {
+      component.form.patchValue({
+        nome: 'Paula Mendes',
+        email: 'paula@carlessopilates.com',
+        cpf: '123.456.111-00',
+        tipoContrato: 'PJ',
+        percentualPagamentoAula: 45,
+        dataInicio: '2024-01-15'
+      });
+
+      component.salvar();
+
+      expect(component.erro).toBe('Identificador inválido.');
+      expect(serviceSpy.cadastrar).not.toHaveBeenCalled();
+      expect(serviceSpy.atualizar).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { ProfissionalFormComponent } from './profissional-form.component';
 import { ProfissionalService } from '../../../core/services/profissional.service';
@@ -148,6 +148,34 @@ describe('ProfissionalFormComponent', () => {
       serviceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
       component.ngOnInit();
       expect(component.erro).toBe('Erro ao carregar profissional.');
+    });
+  });
+
+  describe('with invalid id in route', () => {
+    let component: ProfissionalFormComponent;
+    let fixture: ComponentFixture<ProfissionalFormComponent>;
+    let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+
+    beforeEach(async () => {
+      serviceSpy = jasmine.createSpyObj('ProfissionalService', ['buscar', 'cadastrar', 'atualizar']);
+
+      await TestBed.configureTestingModule({
+        imports: [ProfissionalFormComponent, RouterTestingModule],
+        providers: [
+          { provide: ProfissionalService, useValue: serviceSpy },
+          { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ id: 'abc' }) } } }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ProfissionalFormComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should not load profissional or enter edit mode', () => {
+      expect(component.erro).toBe('Identificador inválido.');
+      expect(component.isEdit).toBeFalse();
+      expect(serviceSpy.buscar).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProfissionalService } from '../../../core/services/profissional.service';
 import { TIPO_CONTRATO_LABEL, TipoContrato } from '../../../core/models/profissional';
+import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-profissional-form',
@@ -40,11 +41,16 @@ export class ProfissionalFormComponent implements OnInit {
       dataInicio: ['', Validators.required]
     });
 
-    const id = this.route.snapshot.paramMap.get('id');
-    if (!id) return;
+    const rawId = this.route.snapshot.paramMap.get('id');
+    if (rawId === null) return;
+
+    this.profissionalId = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
+    if (this.profissionalId === null) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
 
     this.isEdit = true;
-    this.profissionalId = +id;
     this.loading = true;
     this.service.buscar(this.profissionalId).subscribe({
       next: profissional => {

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
@@ -19,6 +19,7 @@ export class ProfissionalFormComponent implements OnInit {
   loading = false;
   salvando = false;
   erro: string | null = null;
+  parametroInvalido = false;
 
   readonly tiposContrato: TipoContrato[] = ['CLT', 'PJ', 'AUTONOMO'];
   readonly tipoContratoLabel = TIPO_CONTRATO_LABEL;
@@ -46,6 +47,7 @@ export class ProfissionalFormComponent implements OnInit {
 
     this.profissionalId = parseRouteNumberParam(this.route.snapshot.paramMap, 'id');
     if (this.profissionalId === null) {
+      this.parametroInvalido = true;
       this.erro = 'Identificador inválido.';
       return;
     }
@@ -66,6 +68,10 @@ export class ProfissionalFormComponent implements OnInit {
   }
 
   salvar(): void {
+    if (this.parametroInvalido) {
+      this.erro = 'Identificador inválido.';
+      return;
+    }
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;

--- a/src/app/shared/utils/route-param.spec.ts
+++ b/src/app/shared/utils/route-param.spec.ts
@@ -1,0 +1,22 @@
+import { convertToParamMap } from '@angular/router';
+import { parseRouteNumberParam } from './route-param';
+
+describe('parseRouteNumberParam', () => {
+  it('should parse numeric route params', () => {
+    const paramMap = convertToParamMap({ pacienteId: '10' });
+
+    expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBe(10);
+  });
+
+  it('should return null when route param is missing', () => {
+    const paramMap = convertToParamMap({});
+
+    expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBeNull();
+  });
+
+  it('should return null when route param is not numeric', () => {
+    const paramMap = convertToParamMap({ pacienteId: 'abc' });
+
+    expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBeNull();
+  });
+});

--- a/src/app/shared/utils/route-param.spec.ts
+++ b/src/app/shared/utils/route-param.spec.ts
@@ -19,4 +19,18 @@ describe('parseRouteNumberParam', () => {
 
     expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBeNull();
   });
+
+  it('should return null for non-positive, decimal or non-finite values', () => {
+    ['0', '-1', '1.5', '1e2', 'Infinity', ' ', '0x10'].forEach(value => {
+      const paramMap = convertToParamMap({ pacienteId: value });
+
+      expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBeNull();
+    });
+  });
+
+  it('should return null when route param is outside safe integer range', () => {
+    const paramMap = convertToParamMap({ pacienteId: '9007199254740992' });
+
+    expect(parseRouteNumberParam(paramMap, 'pacienteId')).toBeNull();
+  });
 });

--- a/src/app/shared/utils/route-param.ts
+++ b/src/app/shared/utils/route-param.ts
@@ -1,0 +1,9 @@
+import { ParamMap } from '@angular/router';
+
+export function parseRouteNumberParam(paramMap: ParamMap, name: string): number | null {
+  const raw = paramMap.get(name);
+  if (raw === null) return null;
+
+  const value = Number(raw);
+  return Number.isNaN(value) ? null : value;
+}

--- a/src/app/shared/utils/route-param.ts
+++ b/src/app/shared/utils/route-param.ts
@@ -3,7 +3,8 @@ import { ParamMap } from '@angular/router';
 export function parseRouteNumberParam(paramMap: ParamMap, name: string): number | null {
   const raw = paramMap.get(name);
   if (raw === null) return null;
+  if (!/^[1-9]\d*$/.test(raw)) return null;
 
   const value = Number(raw);
-  return Number.isNaN(value) ? null : value;
+  return Number.isSafeInteger(value) ? value : null;
 }


### PR DESCRIPTION
## Resumo
- adiciona utilitário para converter parâmetros numéricos de rota sem propagar NaN
- bloqueia chamadas de Planos, Pagamentos e Aulas quando pacienteId/pagamentoId é inválido
- adiciona testes para IDs inválidos e atualiza README/docs

## Testes
- npm test -- --watch=false --browsers=ChromeHeadless
- npm run build

Closes #20