### PR TITLE
fix: corrige NaN e seletor vazio na paginacao de pacientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Arquivos de teste:
 | `/profissionais/:id`    | Detalhes do profissional                    |
 | `/profissionais/:id/editar` | Formulário de edição de profissional    |
 
-Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API junto de `page`, `size` e `sort=nome`. O status padrão é **Ativos**. A paginação exibe o intervalo atual, total de pacientes, navegação por página, botões anterior/próxima e seletor de itens por página. A ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
+Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API junto de `page`, `size` e `sort=nome`. O status padrão é **Ativos**. A paginação exibe o intervalo atual, total de pacientes, navegação por página, botões anterior/próxima e seletor de itens por página. Os metadados são lidos da estrutura aninhada `page.page.*` do Spring Boot 3.x, com fallback para o estado atual quando algum atributo está ausente, evitando `NaN` no resumo e seletor vazio. A ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
 
 Na listagem de profissionais, a paginação server-side renderiza no máximo 5 botões de página por vez, evitando excesso de elementos no DOM em datasets grandes.
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -25,6 +25,7 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 11. Implementação de paginação completa na consulta de pacientes, com resumo de registros, tamanho de página configurável e navegação anterior/próxima
 12. Correção da paginação de profissionais para renderizar uma janela máxima de 5 botões de página
 13. Validação de parâmetros numéricos de rota para evitar chamadas à API com `NaN`
+14. Correção da paginação de pacientes contra resposta aninhada do Spring Boot 3.x (`page.page.*`), com fallback nos metadados para evitar `NaN` no resumo e seletor de tamanho de página em branco
 
 A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side e limita os botões visíveis a uma janela de 5 páginas para evitar excesso de elementos no DOM. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -135,15 +135,23 @@ interface PacienteUpdateDTO {
 }
 ```
 
-### `Page<T>`
-Wrapper de resposta paginada da API.
+### `PageMetadata`
+Metadados de paginação retornados aninhados pelo Spring Boot 3.x.
 ```typescript
-interface Page<T> {
-  content: T[];
+interface PageMetadata {
   totalElements: number;
   totalPages: number;
   size: number;
   number: number;
+}
+```
+
+### `Page<T>`
+Wrapper de resposta paginada da API. Os metadados ficam em `page.page` (estrutura aninhada do Spring Boot 3.x). O componente que consome essa resposta aplica fallback para os campos `number`, `size`, `totalPages` e `totalElements` para preservar o estado anterior caso o backend omita algum atributo, evitando exibição de `NaN` no resumo e seletor vazio na listagem de pacientes.
+```typescript
+interface Page<T> {
+  content: T[];
+  page: PageMetadata;
 }
 ```
 

--- a/src/app/core/models/paciente.ts
+++ b/src/app/core/models/paciente.ts
@@ -35,10 +35,14 @@ export interface PacienteUpdateDTO {
   endereco?: EnderecoDTO;
 }
 
-export interface Page<T> {
-  content: T[];
+export interface PageMetadata {
   totalElements: number;
   totalPages: number;
   size: number;
   number: number;
+}
+
+export interface Page<T> {
+  content: T[];
+  page: PageMetadata;
 }

--- a/src/app/core/services/paciente.service.spec.ts
+++ b/src/app/core/services/paciente.service.spec.ts
@@ -16,10 +16,7 @@ const mockPaciente: PacienteResponseDTO = {
 
 const mockPage: Page<PacienteResponseDTO> = {
   content: [mockPaciente],
-  totalElements: 1,
-  totalPages: 1,
-  size: 10,
-  number: 0
+  page: { totalElements: 1, totalPages: 1, size: 10, number: 0 }
 };
 
 describe('PacienteService', () => {
@@ -45,7 +42,7 @@ describe('PacienteService', () => {
     it('should GET /api/pacientes with default params (page=0, size=10, sort=nome)', () => {
       service.listar().subscribe(page => {
         expect(page.content).toEqual([mockPaciente]);
-        expect(page.totalPages).toBe(1);
+        expect(page.page.totalPages).toBe(1);
       });
 
       const req = httpMock.expectOne(r => r.url === '/api/pacientes');
@@ -62,7 +59,7 @@ describe('PacienteService', () => {
       const req = httpMock.expectOne(r => r.url === '/api/pacientes');
       expect(req.request.params.get('page')).toBe('2');
       expect(req.request.params.get('size')).toBe('5');
-      req.flush({ ...mockPage, size: 5, number: 2 });
+      req.flush({ ...mockPage, page: { ...mockPage.page, size: 5, number: 2 } });
     });
 
     it('should pass filter params when provided', () => {

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -22,10 +22,7 @@ const mockProfissional: ProfissionalResponseDTO = {
 
 const mockPage: ProfissionalPage = {
   content: [mockProfissional],
-  totalElements: 1,
-  totalPages: 1,
-  size: 10,
-  number: 0
+  page: { totalElements: 1, totalPages: 1, size: 10, number: 0 }
 };
 
 describe('ProfissionalService', () => {

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.html
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.html
@@ -53,8 +53,8 @@
 
     <label>
       Itens por página
-      <select #pageSizeSelect [value]="pageSize" (change)="alterarTamanhoPagina(pageSizeSelect.value)">
-        <option *ngFor="let size of pageSizeOptions" [value]="size">{{ size }}</option>
+      <select #pageSizeSelect (change)="alterarTamanhoPagina(pageSizeSelect.value)">
+        <option *ngFor="let size of pageSizeOptions" [value]="size" [selected]="size === pageSize">{{ size }}</option>
       </select>
     </label>
   </div>

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
@@ -18,10 +18,7 @@ const mockPaciente: PacienteResponseDTO = {
 
 const mockPage: Page<PacienteResponseDTO> = {
   content: [mockPaciente],
-  totalElements: 21,
-  totalPages: 3,
-  size: 10,
-  number: 0
+  page: { totalElements: 21, totalPages: 3, size: 10, number: 0 }
 };
 
 describe('PacienteListComponent', () => {
@@ -32,9 +29,8 @@ describe('PacienteListComponent', () => {
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('PacienteService', ['listar', 'inativar', 'ativar']);
     serviceSpy.listar.and.callFake((page = 0, size = 10) => of({
-      ...mockPage,
-      number: page,
-      size
+      content: mockPage.content,
+      page: { ...mockPage.page, number: page, size }
     }));
 
     await TestBed.configureTestingModule({
@@ -227,17 +223,11 @@ describe('PacienteListComponent', () => {
     serviceSpy.listar.and.returnValues(
       of({
         content: [],
-        totalElements: 20,
-        totalPages: 2,
-        size: 10,
-        number: 2
+        page: { totalElements: 20, totalPages: 2, size: 10, number: 2 }
       }),
       of({
         content: [mockPaciente],
-        totalElements: 20,
-        totalPages: 2,
-        size: 10,
-        number: 1
+        page: { totalElements: 20, totalPages: 2, size: 10, number: 1 }
       })
     );
     component.currentPage = 2;
@@ -371,5 +361,64 @@ describe('PacienteListComponent', () => {
   it('should return zero as pageStart when there are no elements', () => {
     component.totalElements = 0;
     expect(component.pageStart()).toBe(0);
+  });
+
+  it('should fall back to current values when API returns metadata with undefined number/size', () => {
+    serviceSpy.listar.and.returnValue(of({
+      content: [mockPaciente],
+      page: {
+        totalElements: 1,
+        totalPages: 1,
+        size: undefined as unknown as number,
+        number: undefined as unknown as number
+      }
+    }));
+    component.currentPage = 0;
+    component.pageSize = 10;
+
+    component.carregar();
+
+    expect(component.currentPage).toBe(0);
+    expect(component.pageSize).toBe(10);
+    expect(Number.isNaN(component.pageStart())).toBeFalse();
+    expect(Number.isNaN(component.pageEnd())).toBeFalse();
+  });
+
+  it('should fall back to current values when API returns no page metadata at all', () => {
+    serviceSpy.listar.and.returnValue(of({
+      content: [mockPaciente]
+    } as Page<PacienteResponseDTO>));
+    component.currentPage = 0;
+    component.pageSize = 10;
+
+    component.carregar();
+
+    expect(component.pacientes).toEqual([mockPaciente]);
+    expect(component.currentPage).toBe(0);
+    expect(component.pageSize).toBe(10);
+    expect(Number.isNaN(component.pageStart())).toBeFalse();
+    expect(Number.isNaN(component.pageEnd())).toBeFalse();
+  });
+
+  it('should ignore unsupported page sizes returned by the API', () => {
+    serviceSpy.listar.and.returnValue(of({
+      content: [mockPaciente],
+      page: { totalElements: 1, totalPages: 1, size: 17, number: 0 }
+    }));
+    component.pageSize = 10;
+
+    component.carregar();
+
+    expect(component.pageSize).toBe(10);
+    expect(component.pageSizeOptions).toContain(component.pageSize);
+  });
+
+  it('should mark the current page size as selected in the dropdown', () => {
+    component.pageSize = 20;
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('.pagination-summary select') as HTMLSelectElement;
+    expect(select).withContext('page size select must be present').toBeTruthy();
+    expect(select.value).toBe('20');
   });
 });

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { PacienteFiltro, PacienteService } from '../../../core/services/paciente.service';
-import { PacienteResponseDTO } from '../../../core/models/paciente';
+import { PacienteResponseDTO, PageMetadata } from '../../../core/models/paciente';
 
 interface FiltroUI {
   nome: string;
@@ -50,17 +50,18 @@ export class PacienteListComponent implements OnInit {
     this.erro = null;
     this.service.listar(this.currentPage, this.pageSize, this.montarFiltro()).subscribe({
       next: page => {
-        if (page.totalPages > 0 && this.currentPage >= page.totalPages) {
-          this.currentPage = Math.max(0, page.totalPages - 1);
+        const meta = page.page ?? ({} as Partial<PageMetadata>);
+        if ((meta.totalPages ?? 0) > 0 && this.currentPage >= (meta.totalPages ?? 0)) {
+          this.currentPage = Math.max(0, (meta.totalPages ?? 1) - 1);
           this.carregar();
           return;
         }
 
         this.pacientes = page.content;
-        this.totalElements = page.totalElements;
-        this.totalPages = page.totalPages;
-        this.currentPage = page.number;
-        this.pageSize = page.size;
+        this.totalElements = meta.totalElements ?? this.totalElements;
+        this.totalPages = meta.totalPages ?? this.totalPages;
+        this.currentPage = meta.number ?? this.currentPage;
+        this.pageSize = this.pageSizeOptions.includes(meta.size as number) ? (meta.size as number) : this.pageSize;
         this.loading = false;
       },
       error: () => {

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
@@ -19,10 +19,7 @@ const mockProfissional: ProfissionalResponseDTO = {
 
 const mockPage: ProfissionalPage = {
   content: [mockProfissional],
-  totalElements: 1,
-  totalPages: 2,
-  size: 10,
-  number: 0
+  page: { totalElements: 1, totalPages: 2, size: 10, number: 0 }
 };
 
 describe('ProfissionalListComponent', () => {

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
@@ -35,7 +35,7 @@ export class ProfissionalListComponent implements OnInit {
     this.service.listar(this.currentPage, this.pageSize).subscribe({
       next: page => {
         this.profissionais = page.content;
-        this.totalPages = page.totalPages;
+        this.totalPages = page.page?.totalPages ?? this.totalPages;
         this.visiblePages = this.pages();
         this.loading = false;
       },


### PR DESCRIPTION
## Summary

- Ajusta `Page<T>` para refletir a estrutura aninhada do Spring Boot 3.x (`page.page.*`) e extrai `PageMetadata` como interface separada.
- Aplica fallback nos metadados (`number`, `size`, `totalPages`, `totalElements`) em `paciente-list.component.ts` para evitar `NaN` no resumo da paginação quando o backend omite atributos. Filtra tamanhos retornados que não estão em `pageSizeOptions`.
- Corrige o `<select>` de itens por página: troca `[value]` no select por `[selected]` em cada `<option>`, garantindo que o tamanho atual fique marcado.
- Atualiza `profissional-list.component.ts` para a estrutura aninhada com fallback.
- Atualiza specs existentes (paciente-list, profissional-list, paciente.service, profissional.service) e adiciona testes para os novos fallbacks: metadados parciais, ausência completa de `page`, size inválido e seletor de tamanho corretamente marcado.
- Atualiza `README.md`, `docs/context.md` e `docs/documentacao.md` refletindo o novo formato.

## Contexto

`pageStart()` / `pageEnd()` retornavam `NaN` porque `currentPage` e `pageSize` ficavam `undefined`: o backend Spring Boot 3.x retorna os metadados aninhados em `page.page.*`, mas o frontend lia da raiz (`page.size`, `page.number`). O `<select>` ficava em branco pelo mesmo motivo — `pageSize` saía do conjunto `[5, 10, 20, 50]` ao receber `undefined`.

## Test plan

- [x] `npm test` — 179/179 testes passando
- [x] `npm run build` — build de produção sem erros
- [x] Validar visualmente a listagem de pacientes em `/pacientes` (resumo, seletor de tamanho, navegação)

🤖 Generated with [Claude Code](https://claude.com/claude-code)