### PR TITLE
fix: adiciona guarda na paginação de profissionais

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Arquivos de teste:
 | Módulo | Descrição |
 |--------|-----------|
 | **Pacientes** | CRUD completo com ativação/inativação, filtros por nome, e-mail, CPF, telefone e status, e paginação com tamanho configurável |
-| **Profissionais** | CRUD completo com ativação/inativação, atualização via PUT e paginação com janela limitada de páginas |
+| **Profissionais** | CRUD completo com ativação/inativação, atualização via PUT e paginação com janela limitada de páginas e guarda de limites |
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
 | **Aulas** | Visualização das aulas geradas e confirmação de presença |
@@ -148,7 +148,7 @@ Arquivos de teste:
 
 Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API junto de `page`, `size` e `sort=nome`. O status padrão é **Ativos**. A paginação exibe o intervalo atual, total de pacientes, navegação por página, botões anterior/próxima e seletor de itens por página. Os metadados são lidos da estrutura aninhada `page.page.*` do Spring Boot 3.x, com fallback para o estado atual quando algum atributo está ausente, evitando `NaN` no resumo e seletor vazio. A ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
 
-Na listagem de profissionais, a paginação server-side renderiza no máximo 5 botões de página por vez, evitando excesso de elementos no DOM em datasets grandes.
+Na listagem de profissionais, a paginação server-side renderiza no máximo 5 botões de página por vez, evitando excesso de elementos no DOM em datasets grandes. A navegação ignora páginas negativas, fora do total retornado pela API ou iguais à página atual, evitando requisições desnecessárias ou fora dos limites.
 
 As rotas que recebem identificadores numéricos validam os parâmetros antes de chamar a API. Apenas inteiros positivos seguros são aceitos; URLs com identificadores ausentes, não numéricos ou em formato inválido exibem a mensagem **Identificador inválido.** e não disparam requisições com `NaN` no caminho.
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -26,8 +26,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 12. Correção da paginação de profissionais para renderizar uma janela máxima de 5 botões de página
 13. Validação de parâmetros numéricos de rota para evitar chamadas à API com `NaN`
 14. Correção da paginação de pacientes contra resposta aninhada do Spring Boot 3.x (`page.page.*`), com fallback nos metadados para evitar `NaN` no resumo e seletor de tamanho de página em branco
+15. Correção da navegação de páginas na listagem de profissionais para ignorar páginas negativas, fora do total retornado ou iguais à página atual
 
-A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side e limita os botões visíveis a uma janela de 5 páginas para evitar excesso de elementos no DOM. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
+A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -32,7 +32,7 @@
 | Módulo | Rotas | Funcionalidades |
 |--------|-------|-----------------|
 | Pacientes | `/pacientes`, `/pacientes/:id`, `/pacientes/novo`, `/pacientes/:id/editar` | CRUD completo, filtros de busca, paginação, ativar/inativar |
-| Profissionais | `/profissionais`, `/profissionais/:id`, `/profissionais/novo`, `/profissionais/:id/editar` | CRUD completo, ativar/inativar, atualização via PUT, paginação com janela limitada |
+| Profissionais | `/profissionais`, `/profissionais/:id`, `/profissionais/novo`, `/profissionais/:id/editar` | CRUD completo, ativar/inativar, atualização via PUT, paginação com janela limitada e guarda de limites |
 | Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
 | Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
 | Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença |
@@ -292,6 +292,7 @@ Os parâmetros numéricos das rotas são validados antes de qualquer chamada à 
 ### `ProfissionalListComponent`
 - Tabela paginada de profissionais ativos
 - Navegação por página com janela de até 5 páginas visíveis para evitar excesso de botões no DOM
+- Guarda de limites na navegação, ignorando páginas negativas, fora do total retornado ou iguais à página atual
 - Colunas: Nome, E-mail, Contrato, % por Aula, Ações
 - Ações: Ver, Editar e Inativar
 - Diálogo de confirmação inline para inativação
@@ -424,7 +425,7 @@ Comando: `npm test`
 - Filtros na listagem de pacientes por nome, e-mail, CPF, telefone e status
 - Paginação da consulta de pacientes com resumo, navegação anterior/próxima, janela de páginas e tamanho de página configurável
 - CRUD completo de profissionais com atualização via PUT
-- Paginação server-side em pacientes e profissionais, com janela limitada de páginas visíveis
+- Paginação server-side em pacientes e profissionais, com janela limitada de páginas visíveis e bloqueio de navegação fora dos limites
 - Validação de formulários
 - Feedback de erros e loading
 - Integração com API REST (contratos alinhados com backend v2)

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
@@ -84,6 +84,27 @@ describe('ProfissionalListComponent', () => {
     expect(component.erro).toBe('Erro ao inativar profissional.');
   });
 
+  it('should change currentPage and reload when pagina is called with a valid page', () => {
+    component.totalPages = 3;
+    component.pagina(1);
+
+    expect(component.currentPage).toBe(1);
+    expect(serviceSpy.listar).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('should ignore invalid or current page when pagina is called', () => {
+    serviceSpy.listar.calls.reset();
+    component.totalPages = 3;
+    component.currentPage = 1;
+
+    component.pagina(-1);
+    component.pagina(1);
+    component.pagina(3);
+
+    expect(component.currentPage).toBe(1);
+    expect(serviceSpy.listar).not.toHaveBeenCalled();
+  });
+
   it('should return all page indices when total pages fit in visible window', () => {
     component.totalPages = 3;
 

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.ts
@@ -70,6 +70,7 @@ export class ProfissionalListComponent implements OnInit {
   }
 
   pagina(p: number): void {
+    if (p < 0 || p >= this.totalPages || p === this.currentPage) return;
     this.currentPage = p;
     this.carregar();
   }


### PR DESCRIPTION
## Resumo
- Corrige `ProfissionalListComponent.pagina()` para ignorar páginas negativas, fora do total retornado e a página atual.
- Adiciona testes unitários para navegação válida e inválida na paginação de profissionais.
- Atualiza README e documentação do projeto com a regra da guarda de limites.

## Testes
- `npm test -- --watch=false --browsers=ChromeHeadless`

Closes #15