### PR TITLE
feat: vincular profissional ao realizar aula

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Arquivos de teste:
 | **Profissionais** | CRUD completo com ativação/inativação, atualização via PUT e paginação com janela limitada de páginas e guarda de limites |
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
-| **Aulas** | Visualização das aulas geradas e confirmação de presença |
+| **Aulas** | Visualização das aulas geradas e confirmação de presença com vínculo do profissional responsável |
 
 ---
 
@@ -160,6 +160,8 @@ As rotas que recebem identificadores numéricos validam os parâmetros antes de 
 | `/pagamentos/novo/:pacienteId` | Registrar novo pagamento |
 | `/aulas/paciente/:pacienteId` | Lista de aulas geradas |
 | `/aulas/pagamento/:pagamentoId` | Lista de aulas por pagamento |
+
+A tela de aulas carrega os profissionais ativos e exige a seleção do profissional antes de marcar uma aula pendente como realizada. A confirmação envia `PATCH /aulas/{id}/realizar` com o corpo `{ "profissionalId": id }`; aulas já realizadas exibem o profissional vinculado quando retornado pela API.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ As rotas que recebem identificadores numéricos validam os parâmetros antes de 
 | `/aulas/paciente/:pacienteId` | Lista de aulas geradas |
 | `/aulas/pagamento/:pagamentoId` | Lista de aulas por pagamento |
 
-A tela de aulas carrega os profissionais ativos e exige a seleção do profissional antes de marcar uma aula pendente como realizada. A confirmação envia `PATCH /aulas/{id}/realizar` com o corpo `{ "profissionalId": id }`; aulas já realizadas exibem o profissional vinculado quando retornado pela API.
+A tela de aulas carrega os profissionais ativos e exige a seleção do profissional antes de marcar uma aula pendente como realizada. A confirmação envia `PATCH /aulas/{id}/realizar?profissionalId={id}`; aulas já realizadas exibem o profissional vinculado quando retornado pela API.
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -27,8 +27,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 13. Validação de parâmetros numéricos de rota para evitar chamadas à API com `NaN`
 14. Correção da paginação de pacientes contra resposta aninhada do Spring Boot 3.x (`page.page.*`), com fallback nos metadados para evitar `NaN` no resumo e seletor de tamanho de página em branco
 15. Correção da navegação de páginas na listagem de profissionais para ignorar páginas negativas, fora do total retornado ou iguais à página atual
+16. Implementação da confirmação de aula realizada com seleção e vínculo do profissional responsável
 
-A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
+A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A tela de aulas permite marcar uma aula como realizada somente após selecionar o profissional responsável, enviando esse vínculo para o backend. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 
@@ -51,6 +52,9 @@ Por regra de negócio, o CPF não pode ser alterado após o cadastro. O formulá
 
 ### Atualização de profissionais via PUT
 O cadastro de profissionais segue o contrato do backend para atualização via `PUT /profissionais/{id}` com `ProfissionalUpdateDTO`. Ativação e inativação continuam usando endpoints específicos com `PATCH`.
+
+### Confirmação de aulas com profissional
+A confirmação de presença em aulas usa `PATCH /aulas/{id}/realizar` com payload `{ profissionalId }`. O frontend carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige seleção antes de confirmar e exibe o profissional retornado em aulas já realizadas.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.

--- a/docs/context.md
+++ b/docs/context.md
@@ -54,7 +54,7 @@ Por regra de negócio, o CPF não pode ser alterado após o cadastro. O formulá
 O cadastro de profissionais segue o contrato do backend para atualização via `PUT /profissionais/{id}` com `ProfissionalUpdateDTO`. Ativação e inativação continuam usando endpoints específicos com `PATCH`.
 
 ### Confirmação de aulas com profissional
-A confirmação de presença em aulas usa `PATCH /aulas/{id}/realizar` com payload `{ profissionalId }`. O frontend carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige seleção antes de confirmar e exibe o profissional retornado em aulas já realizadas.
+A confirmação de presença em aulas usa `PATCH /aulas/{id}/realizar?profissionalId={id}`. O frontend carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige seleção antes de confirmar e exibe o profissional retornado em aulas já realizadas.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -217,14 +217,6 @@ interface AulaResponseDTO {
 }
 ```
 
-### `AulaRealizarRequestDTO`
-Payload para marcar uma aula como realizada vinculando o profissional responsável.
-```typescript
-interface AulaRealizarRequestDTO {
-  profissionalId: number;
-}
-```
-
 ---
 
 ## Serviços
@@ -271,7 +263,7 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 |-------------------|-----------------------------|----------------------------------|
 | `listarPorPaciente(pacienteId)` | `GET /aulas/paciente/{id}` | Lista aulas do paciente |
 | `listarPorPagamento(pagamentoId)` | `GET /aulas/pagamento/{id}` | Lista aulas do pagamento |
-| `realizar(aulaId, profissionalId)` | `PATCH /aulas/{id}/realizar` com `{ profissionalId }` | Marca aula como realizada e vincula o profissional responsável |
+| `realizar(aulaId, profissionalId)` | `PATCH /aulas/{id}/realizar?profissionalId={id}` | Marca aula como realizada e vincula o profissional responsável |
 
 ---
 
@@ -339,7 +331,7 @@ Os parâmetros numéricos das rotas são validados antes de qualquer chamada à 
 - Lista aulas por paciente ou pagamento
 - Carrega profissionais ativos para seleção em aulas pendentes
 - Exige profissional selecionado antes de marcar uma aula como realizada
-- Envia `profissionalId` no `PATCH /aulas/{id}/realizar`
+- Envia `profissionalId` como query param no `PATCH /aulas/{id}/realizar`
 - Exibe o nome do profissional vinculado em aulas realizadas quando retornado pela API
 
 ### `ConfirmarDialogComponent` _(shared)_

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -35,7 +35,7 @@
 | Profissionais | `/profissionais`, `/profissionais/:id`, `/profissionais/novo`, `/profissionais/:id/editar` | CRUD completo, ativar/inativar, atualização via PUT, paginação com janela limitada e guarda de limites |
 | Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
 | Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
-| Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença |
+| Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença e vincular profissional responsável |
 
 ---
 
@@ -200,6 +200,31 @@ interface ProfissionalUpdateDTO {
 }
 ```
 
+Arquivo: `src/app/core/models/plano.ts`
+
+### `AulaResponseDTO`
+Retorno da API ao listar/buscar aulas.
+```typescript
+interface AulaResponseDTO {
+  id: number;
+  pacienteId: number;
+  pacienteNome: string;
+  pagamentoId: number;
+  data: string;
+  realizada: boolean;
+  profissionalId?: number | null;
+  profissionalNome?: string | null;
+}
+```
+
+### `AulaRealizarRequestDTO`
+Payload para marcar uma aula como realizada vinculando o profissional responsável.
+```typescript
+interface AulaRealizarRequestDTO {
+  profissionalId: number;
+}
+```
+
 ---
 
 ## Serviços
@@ -235,6 +260,18 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 | `atualizar(id, dto)` | `PUT /profissionais/{id}`    | Atualiza dados do profissional   |
 | `ativar(id)`      | `PATCH /profissionais/{id}/ativar` | Reativa profissional inativo  |
 | `inativar(id)`    | `PATCH /profissionais/{id}/inativar` | Inativa profissional          |
+
+### `AulaService`
+Arquivo: `src/app/core/services/aula.service.ts`
+Injetável em toda a aplicação (`providedIn: 'root'`).
+
+**URL base no frontend:** `/api`
+
+| Método            | Endpoint HTTP               | Descrição                        |
+|-------------------|-----------------------------|----------------------------------|
+| `listarPorPaciente(pacienteId)` | `GET /aulas/paciente/{id}` | Lista aulas do paciente |
+| `listarPorPagamento(pagamentoId)` | `GET /aulas/pagamento/{id}` | Lista aulas do pagamento |
+| `realizar(aulaId, profissionalId)` | `PATCH /aulas/{id}/realizar` com `{ profissionalId }` | Marca aula como realizada e vincula o profissional responsável |
 
 ---
 
@@ -297,6 +334,13 @@ Os parâmetros numéricos das rotas são validados antes de qualquer chamada à 
 - Ações: Ver, Editar e Inativar
 - Diálogo de confirmação inline para inativação
 - Tratamento de erros e estado de carregamento
+
+### `AulaListComponent`
+- Lista aulas por paciente ou pagamento
+- Carrega profissionais ativos para seleção em aulas pendentes
+- Exige profissional selecionado antes de marcar uma aula como realizada
+- Envia `profissionalId` no `PATCH /aulas/{id}/realizar`
+- Exibe o nome do profissional vinculado em aulas realizadas quando retornado pela API
 
 ### `ConfirmarDialogComponent` _(shared)_
 - Componente gerado, ainda não integrado (diálogos implementados inline nos componentes)
@@ -434,7 +478,7 @@ Comando: `npm test`
 - E-mail mutável na edição (somente CPF é imutável)
 - Módulo Planos: listagem, criação com seleção de dias e validação de frequência
 - Módulo Pagamentos: listagem, criação e confirmação de pagamento (PAGO)
-- Módulo Aulas: listagem e confirmação de presença
+- Módulo Aulas: listagem e confirmação de presença com vínculo do profissional responsável
 - Navegação contextual na tela de detalhe do paciente (Planos / Pagamentos / Aulas)
 - Dockerfile, Docker Compose e Nginx para execução do frontend em container
 - Testes unitários (serviço e todos os componentes de página)

--- a/src/app/core/models/plano.ts
+++ b/src/app/core/models/plano.ts
@@ -55,10 +55,6 @@ export interface AulaResponseDTO {
   profissionalNome?: string | null;
 }
 
-export interface AulaRealizarRequestDTO {
-  profissionalId: number;
-}
-
 export const DIAS_SEMANA_LABEL: Record<DiaSemana, string> = {
   MONDAY: 'Segunda',
   TUESDAY: 'Terça',

--- a/src/app/core/models/plano.ts
+++ b/src/app/core/models/plano.ts
@@ -51,6 +51,12 @@ export interface AulaResponseDTO {
   pagamentoId: number;
   data: string;
   realizada: boolean;
+  profissionalId?: number | null;
+  profissionalNome?: string | null;
+}
+
+export interface AulaRealizarRequestDTO {
+  profissionalId: number;
 }
 
 export const DIAS_SEMANA_LABEL: Record<DiaSemana, string> = {

--- a/src/app/core/services/aula.service.spec.ts
+++ b/src/app/core/services/aula.service.spec.ts
@@ -50,11 +50,13 @@ describe('AulaService', () => {
   });
 
   describe('realizar', () => {
-    it('should PATCH /api/aulas/:id/realizar', () => {
+    it('should PATCH /api/aulas/:id/realizar with profissionalId query param', () => {
       service.realizar(1, 5).subscribe(aula => expect(aula).toEqual(mockAula));
-      const req = httpMock.expectOne('/api/aulas/1/realizar');
+      const req = httpMock.expectOne(request =>
+        request.url === '/api/aulas/1/realizar' && request.params.get('profissionalId') === '5'
+      );
       expect(req.request.method).toBe('PATCH');
-      expect(req.request.body).toEqual({ profissionalId: 5 });
+      expect(req.request.body).toEqual({});
       req.flush(mockAula);
     });
   });

--- a/src/app/core/services/aula.service.spec.ts
+++ b/src/app/core/services/aula.service.spec.ts
@@ -51,9 +51,10 @@ describe('AulaService', () => {
 
   describe('realizar', () => {
     it('should PATCH /api/aulas/:id/realizar', () => {
-      service.realizar(1).subscribe(aula => expect(aula).toEqual(mockAula));
+      service.realizar(1, 5).subscribe(aula => expect(aula).toEqual(mockAula));
       const req = httpMock.expectOne('/api/aulas/1/realizar');
       expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ profissionalId: 5 });
       req.flush(mockAula);
     });
   });

--- a/src/app/core/services/aula.service.ts
+++ b/src/app/core/services/aula.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AulaRealizarRequestDTO, AulaResponseDTO } from '../models/plano';
+import { AulaResponseDTO } from '../models/plano';
 
 @Injectable({ providedIn: 'root' })
 export class AulaService {
@@ -18,7 +18,7 @@ export class AulaService {
   }
 
   realizar(aulaId: number, profissionalId: number): Observable<AulaResponseDTO> {
-    const dto: AulaRealizarRequestDTO = { profissionalId };
-    return this.http.patch<AulaResponseDTO>(`${this.apiUrl}/aulas/${aulaId}/realizar`, dto);
+    const params = new HttpParams().set('profissionalId', profissionalId);
+    return this.http.patch<AulaResponseDTO>(`${this.apiUrl}/aulas/${aulaId}/realizar`, {}, { params });
   }
 }

--- a/src/app/core/services/aula.service.ts
+++ b/src/app/core/services/aula.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AulaResponseDTO } from '../models/plano';
+import { AulaRealizarRequestDTO, AulaResponseDTO } from '../models/plano';
 
 @Injectable({ providedIn: 'root' })
 export class AulaService {
@@ -17,7 +17,8 @@ export class AulaService {
     return this.http.get<AulaResponseDTO[]>(`${this.apiUrl}/aulas/pagamento/${pagamentoId}`);
   }
 
-  realizar(aulaId: number): Observable<AulaResponseDTO> {
-    return this.http.patch<AulaResponseDTO>(`${this.apiUrl}/aulas/${aulaId}/realizar`, {});
+  realizar(aulaId: number, profissionalId: number): Observable<AulaResponseDTO> {
+    const dto: AulaRealizarRequestDTO = { profissionalId };
+    return this.http.patch<AulaResponseDTO>(`${this.apiUrl}/aulas/${aulaId}/realizar`, dto);
   }
 }

--- a/src/app/pages/aulas/aula-list/aula-list.component.html
+++ b/src/app/pages/aulas/aula-list/aula-list.component.html
@@ -16,6 +16,7 @@
     <tr>
       <th>Data</th>
       <th>Status</th>
+      <th>Profissional</th>
       <th>Ações</th>
     </tr>
   </thead>
@@ -28,7 +29,18 @@
         </span>
       </td>
       <td>
-        <button class="btn btn-secondary btn-sm" *ngIf="!aula.realizada" (click)="realizar(aula.id)">
+        <span *ngIf="aula.realizada">{{ aula.profissionalNome || '-' }}</span>
+        <select *ngIf="!aula.realizada" class="form-control form-control-sm"
+          [(ngModel)]="profissionalSelecionadoPorAula[aula.id]">
+          <option [ngValue]="null">Selecione</option>
+          <option *ngFor="let profissional of profissionais" [ngValue]="profissional.id">
+            {{ profissional.nome }}
+          </option>
+        </select>
+      </td>
+      <td>
+        <button class="btn btn-secondary btn-sm" *ngIf="!aula.realizada" (click)="realizar(aula.id)"
+          [disabled]="profissionais.length === 0">
           Marcar como Realizada
         </button>
       </td>

--- a/src/app/pages/aulas/aula-list/aula-list.component.scss
+++ b/src/app/pages/aulas/aula-list/aula-list.component.scss
@@ -3,4 +3,28 @@
 .badge-pendente { background: #f5f5f5; color: var(--text-light); }
 .btn-sm { padding: 4px 10px; font-size: 0.85rem; }
 .empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }
-.form-control-sm { max-width: 240px; padding: 4px 8px; font-size: 0.9rem; }
+
+:host {
+  color-scheme: light;
+}
+
+.table {
+  background: var(--white);
+  color: var(--text);
+
+  tbody tr {
+    background: var(--white);
+  }
+
+  td {
+    color: var(--text);
+  }
+}
+
+.form-control-sm {
+  max-width: 240px;
+  padding: 4px 8px;
+  font-size: 0.9rem;
+  background: var(--white);
+  color: var(--text);
+}

--- a/src/app/pages/aulas/aula-list/aula-list.component.scss
+++ b/src/app/pages/aulas/aula-list/aula-list.component.scss
@@ -3,3 +3,4 @@
 .badge-pendente { background: #f5f5f5; color: var(--text-light); }
 .btn-sm { padding: 4px 10px; font-size: 0.85rem; }
 .empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }
+.form-control-sm { max-width: 240px; padding: 4px 8px; font-size: 0.9rem; }

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -7,7 +7,9 @@ import { of, throwError } from 'rxjs';
 import { AulaListComponent } from './aula-list.component';
 import { AulaService } from '../../../core/services/aula.service';
 import { PagamentoService } from '../../../core/services/pagamento.service';
+import { ProfissionalService } from '../../../core/services/profissional.service';
 import { AulaResponseDTO, PagamentoResponseDTO } from '../../../core/models/plano';
+import { ProfissionalPage, ProfissionalResponseDTO } from '../../../core/models/profissional';
 
 const mockAula: AulaResponseDTO = {
   id: 1, pacienteId: 10, pacienteNome: 'Ana Silva', pagamentoId: 1, data: '2026-05-05', realizada: false
@@ -19,6 +21,23 @@ const mockPagamento: PagamentoResponseDTO = {
   dataVencimento: '2026-05-10', periodoInicio: '2026-05-01', periodoFim: '2026-05-31'
 };
 
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 5,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+const mockProfissionalPage: ProfissionalPage = {
+  content: [mockProfissional],
+  page: { totalElements: 1, totalPages: 1, size: 100, number: 0 }
+};
+
 registerLocaleData(localePt);
 
 describe('AulaListComponent', () => {
@@ -27,17 +46,21 @@ describe('AulaListComponent', () => {
     let fixture: ComponentFixture<AulaListComponent>;
     let serviceSpy: jasmine.SpyObj<AulaService>;
     let pagamentoServiceSpy: jasmine.SpyObj<PagamentoService>;
+    let profissionalServiceSpy: jasmine.SpyObj<ProfissionalService>;
 
     beforeEach(async () => {
       serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
       pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+      profissionalServiceSpy = jasmine.createSpyObj('ProfissionalService', ['listar']);
       serviceSpy.listarPorPaciente.and.returnValue(of([mockAula]));
+      profissionalServiceSpy.listar.and.returnValue(of(mockProfissionalPage));
 
       await TestBed.configureTestingModule({
         imports: [AulaListComponent, RouterTestingModule],
         providers: [
           { provide: AulaService, useValue: serviceSpy },
           { provide: PagamentoService, useValue: pagamentoServiceSpy },
+          { provide: ProfissionalService, useValue: profissionalServiceSpy },
           { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pacienteId' ? '10' : null } } } }
         ]
       }).compileComponents();
@@ -51,8 +74,16 @@ describe('AulaListComponent', () => {
 
     it('should load aulas on init', () => {
       expect(serviceSpy.listarPorPaciente).toHaveBeenCalledWith(10);
+      expect(profissionalServiceSpy.listar).toHaveBeenCalledWith(0, 100);
       expect(component.aulas).toEqual([mockAula]);
+      expect(component.profissionais).toEqual([mockProfissional]);
       expect(component.loading).toBeFalse();
+    });
+
+    it('should set erro when profissionais fail to load', () => {
+      profissionalServiceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+      component.carregarProfissionais();
+      expect(component.erro).toBe('Erro ao carregar profissionais.');
     });
 
     it('should set erro when listar fails', () => {
@@ -63,13 +94,22 @@ describe('AulaListComponent', () => {
 
     it('should call realizar and reload on success', () => {
       serviceSpy.realizar.and.returnValue(of({ ...mockAula, realizada: true }));
+      component.profissionalSelecionadoPorAula[1] = 5;
       component.realizar(1);
-      expect(serviceSpy.realizar).toHaveBeenCalledWith(1);
+      expect(serviceSpy.realizar).toHaveBeenCalledWith(1, 5);
       expect(serviceSpy.listarPorPaciente).toHaveBeenCalledTimes(2);
+    });
+
+    it('should require profissional before realizar', () => {
+      component.profissionalSelecionadoPorAula[1] = null;
+      component.realizar(1);
+      expect(component.erro).toBe('Selecione um profissional para marcar a aula como realizada.');
+      expect(serviceSpy.realizar).not.toHaveBeenCalled();
     });
 
     it('should set erro when realizar fails', () => {
       serviceSpy.realizar.and.returnValue(throwError(() => new Error('fail')));
+      component.profissionalSelecionadoPorAula[1] = 5;
       component.realizar(1);
       expect(component.erro).toBe('Erro ao marcar aula como realizada.');
     });
@@ -80,18 +120,22 @@ describe('AulaListComponent', () => {
     let fixture: ComponentFixture<AulaListComponent>;
     let serviceSpy: jasmine.SpyObj<AulaService>;
     let pagamentoServiceSpy: jasmine.SpyObj<PagamentoService>;
+    let profissionalServiceSpy: jasmine.SpyObj<ProfissionalService>;
 
     beforeEach(async () => {
       serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
       pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+      profissionalServiceSpy = jasmine.createSpyObj('ProfissionalService', ['listar']);
       serviceSpy.listarPorPagamento.and.returnValue(of([mockAula]));
       pagamentoServiceSpy.buscar.and.returnValue(of(mockPagamento));
+      profissionalServiceSpy.listar.and.returnValue(of(mockProfissionalPage));
 
       await TestBed.configureTestingModule({
         imports: [AulaListComponent, RouterTestingModule],
         providers: [
           { provide: AulaService, useValue: serviceSpy },
           { provide: PagamentoService, useValue: pagamentoServiceSpy },
+          { provide: ProfissionalService, useValue: profissionalServiceSpy },
           { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (key: string) => key === 'pagamentoId' ? '1' : null } } } }
         ]
       }).compileComponents();
@@ -104,6 +148,7 @@ describe('AulaListComponent', () => {
     it('should fetch payment to resolve pacienteId then load aulas', () => {
       expect(pagamentoServiceSpy.buscar).toHaveBeenCalledWith(1);
       expect(serviceSpy.listarPorPagamento).toHaveBeenCalledWith(1);
+      expect(profissionalServiceSpy.listar).toHaveBeenCalledWith(0, 100);
       expect(component.pacienteId).toBe(10);
       expect(component.titulo).toBe('Aulas do Pagamento');
     });
@@ -118,8 +163,9 @@ describe('AulaListComponent', () => {
   it('should not load aulas when route param is invalid', () => {
     const serviceSpy = jasmine.createSpyObj('AulaService', ['listarPorPaciente', 'listarPorPagamento', 'realizar']);
     const pagamentoServiceSpy = jasmine.createSpyObj('PagamentoService', ['buscar']);
+    const profissionalServiceSpy = jasmine.createSpyObj('ProfissionalService', ['listar']);
     const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
-    const component = new AulaListComponent(serviceSpy, pagamentoServiceSpy, invalidRoute);
+    const component = new AulaListComponent(serviceSpy, pagamentoServiceSpy, profissionalServiceSpy, invalidRoute);
 
     component.ngOnInit();
 
@@ -127,5 +173,6 @@ describe('AulaListComponent', () => {
     expect(serviceSpy.listarPorPaciente).not.toHaveBeenCalled();
     expect(serviceSpy.listarPorPagamento).not.toHaveBeenCalled();
     expect(pagamentoServiceSpy.buscar).not.toHaveBeenCalled();
+    expect(profissionalServiceSpy.listar).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -1,14 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AulaService } from '../../../core/services/aula.service';
 import { PagamentoService } from '../../../core/services/pagamento.service';
+import { ProfissionalService } from '../../../core/services/profissional.service';
 import { AulaResponseDTO } from '../../../core/models/plano';
+import { ProfissionalResponseDTO } from '../../../core/models/profissional';
 import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 
 @Component({
   selector: 'app-aula-list',
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './aula-list.component.html',
   styleUrl: './aula-list.component.scss'
 })
@@ -16,6 +19,8 @@ export class AulaListComponent implements OnInit {
   pacienteId: number | null = null;
   pagamentoId: number | null = null;
   aulas: AulaResponseDTO[] = [];
+  profissionais: ProfissionalResponseDTO[] = [];
+  profissionalSelecionadoPorAula: Record<number, number | null> = {};
   loading = false;
   erro: string | null = null;
   titulo = 'Aulas';
@@ -23,6 +28,7 @@ export class AulaListComponent implements OnInit {
   constructor(
     private service: AulaService,
     private pagamentoService: PagamentoService,
+    private profissionalService: ProfissionalService,
     private route: ActivatedRoute
   ) {}
 
@@ -44,6 +50,8 @@ export class AulaListComponent implements OnInit {
       return;
     }
 
+    this.carregarProfissionais();
+
     if (this.pagamentoId !== null) {
       this.pagamentoService.buscar(this.pagamentoId).subscribe({
         next: pagamento => {
@@ -57,6 +65,17 @@ export class AulaListComponent implements OnInit {
     } else {
       this.carregar();
     }
+  }
+
+  carregarProfissionais(): void {
+    this.profissionalService.listar(0, 100).subscribe({
+      next: page => {
+        this.profissionais = page.content;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar profissionais.';
+      }
+    });
   }
 
   carregar(): void {
@@ -73,6 +92,10 @@ export class AulaListComponent implements OnInit {
     request$.subscribe({
       next: aulas => {
         this.aulas = aulas;
+        this.profissionalSelecionadoPorAula = aulas.reduce<Record<number, number | null>>((acc, aula) => {
+          acc[aula.id] = aula.profissionalId ?? null;
+          return acc;
+        }, {});
         this.loading = false;
       },
       error: () => {
@@ -83,7 +106,13 @@ export class AulaListComponent implements OnInit {
   }
 
   realizar(id: number): void {
-    this.service.realizar(id).subscribe({
+    const profissionalId = this.profissionalSelecionadoPorAula[id];
+    if (!profissionalId) {
+      this.erro = 'Selecione um profissional para marcar a aula como realizada.';
+      return;
+    }
+
+    this.service.realizar(id, profissionalId).subscribe({
       next: () => this.carregar(),
       error: () => (this.erro = 'Erro ao marcar aula como realizada.')
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
+import { registerLocaleData } from '@angular/common';
+import localePt from '@angular/common/locales/pt';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+
+registerLocaleData(localePt);
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Resumo
- Adiciona seleção de profissional ativo na listagem de aulas pendentes.
- Envia `profissionalId` como query param no `PATCH /aulas/{id}/realizar?profissionalId={id}` e exibe o profissional em aulas realizadas quando retornado pela API.
- Registra o locale `pt` no bootstrap para o pipe de data renderizar as linhas da tabela de aulas corretamente.
- Ajusta estilos da tabela de aulas para manter conteúdo legível no tema atual.
- Atualiza modelos, testes unitários, README e documentação do projeto.

Closes #33

## Testes
- `npm test -- --watch=false --browsers=ChromeHeadless`
- `npm run build`
- Verificação headless em `http://127.0.0.1:4201/aulas/paciente/1` confirmando datas, status, select de profissionais e botão renderizados.