### PR TITLE
feat: criar seção de relatórios e relatório de pagamento profissional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Interface web para gestão administrativa de um estúdio de pilates, desenvolvid
 
 ## Visão Geral
 
-A aplicação oferece CRUDs administrativos para pacientes e profissionais, além de fluxos de planos, pagamentos e aulas. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
+A aplicação oferece CRUDs administrativos para pacientes e profissionais, fluxos de planos, pagamentos e aulas, além de relatórios administrativos. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
 
 **Documentação detalhada:** [`docs/documentacao.md`](docs/documentacao.md)  
 **Contexto e decisões técnicas:** [`docs/context.md`](docs/context.md)
@@ -94,6 +94,7 @@ src/app/
 │   ├── paciente-form/              # Cadastro e edição
 │   └── paciente-detail/            # Visualização detalhada
 ├── pages/profissionais/            # CRUD de profissionais
+├── pages/relatorios/               # Relatórios administrativos
 └── shared/components/              # Componentes reutilizáveis
 ```
 
@@ -117,6 +118,8 @@ Arquivos de teste:
 - `src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts`
 - `src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts`
 - `src/app/pages/profissionais/profissional-detail/profissional-detail.component.spec.ts`
+- `src/app/pages/relatorios/relatorio-list/relatorio-list.component.spec.ts`
+- `src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.spec.ts`
 
 ---
 
@@ -129,6 +132,7 @@ Arquivos de teste:
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
 | **Aulas** | Visualização das aulas geradas e confirmação de presença com vínculo do profissional responsável |
+| **Relatórios** | Seção administrativa com relatório de pagamento de profissional por período |
 
 ---
 
@@ -145,6 +149,8 @@ Arquivos de teste:
 | `/profissionais/novo`   | Formulário de cadastro de profissional      |
 | `/profissionais/:id`    | Detalhes do profissional                    |
 | `/profissionais/:id/editar` | Formulário de edição de profissional    |
+| `/relatorios`           | Seção de relatórios                         |
+| `/relatorios/pagamento-profissional` | Relatório de pagamento de profissional |
 
 Na listagem de pacientes, os filtros enviam os parâmetros `nome`, `email`, `cpf`, `telefone` e `ativo` para a API junto de `page`, `size` e `sort=nome`. O status padrão é **Ativos**. A paginação exibe o intervalo atual, total de pacientes, navegação por página, botões anterior/próxima e seletor de itens por página. Os metadados são lidos da estrutura aninhada `page.page.*` do Spring Boot 3.x, com fallback para o estado atual quando algum atributo está ausente, evitando `NaN` no resumo e seletor vazio. A ação da linha muda conforme o status: **Inativar** para pacientes ativos, **Ativar** para inativos. A tela de detalhe também exibe links de navegação para Planos, Pagamentos e Aulas do paciente.
 
@@ -162,6 +168,8 @@ As rotas que recebem identificadores numéricos validam os parâmetros antes de 
 | `/aulas/pagamento/:pagamentoId` | Lista de aulas por pagamento |
 
 A tela de aulas carrega os profissionais ativos e exige a seleção do profissional antes de marcar uma aula pendente como realizada. A confirmação envia `PATCH /aulas/{id}/realizar?profissionalId={id}`; aulas já realizadas exibem o profissional vinculado quando retornado pela API.
+
+O relatório de pagamento de profissional carrega os profissionais ativos para seleção, exige período inicial e final, valida que a data inicial não seja posterior à final e consulta `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. O resultado exibe totais consolidados e detalhamento por aula realizada.
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -28,8 +28,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 14. Correção da paginação de pacientes contra resposta aninhada do Spring Boot 3.x (`page.page.*`), com fallback nos metadados para evitar `NaN` no resumo e seletor de tamanho de página em branco
 15. Correção da navegação de páginas na listagem de profissionais para ignorar páginas negativas, fora do total retornado ou iguais à página atual
 16. Implementação da confirmação de aula realizada com seleção e vínculo do profissional responsável
+17. Criação da seção de relatórios e do relatório de pagamento de profissional por período
 
-A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A tela de aulas permite marcar uma aula como realizada somente após selecionar o profissional responsável, enviando esse vínculo para o backend. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
+A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A tela de aulas permite marcar uma aula como realizada somente após selecionar o profissional responsável, enviando esse vínculo para o backend. A seção de relatórios já possui consulta de pagamento de profissional por período, com seleção de profissional ativo, validação de datas e detalhamento por aula realizada. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 
@@ -55,6 +56,9 @@ O cadastro de profissionais segue o contrato do backend para atualização via `
 
 ### Confirmação de aulas com profissional
 A confirmação de presença em aulas usa `PATCH /aulas/{id}/realizar?profissionalId={id}`. O frontend carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige seleção antes de confirmar e exibe o profissional retornado em aulas já realizadas.
+
+### Relatório de pagamento de profissional
+O relatório usa `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. A tela valida seleção de profissional, datas obrigatórias e impede consulta quando a data inicial é posterior à final. O retorno consolida total de aulas, total devido e detalhamento por aula, incluindo paciente, pagamento, valor base por aula, percentual do profissional e valor devido.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.
@@ -114,7 +118,7 @@ A configuração por `environment.ts` ainda não é necessária porque o fronten
 | Agendamentos   | Vínculo paciente ↔ aula ↔ data/hora           |
 | Frequência     | Controle de presença por sessão               |
 | Financeiro     | Planos, pagamentos e cobranças                |
-| Relatórios     | Dashboard com métricas do estúdio             |
+| Relatórios     | Relatório de pagamento de profissional por período; futuros dashboards e métricas do estúdio |
 
 ---
 
@@ -149,6 +153,7 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 - `PUT /profissionais/{id}` (body: `ProfissionalUpdateDTO`) → `ProfissionalResponseDTO`
 - `PATCH /profissionais/{id}/ativar` → `204 No Content`
 - `PATCH /profissionais/{id}/inativar` → `204 No Content`
+- `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` → `ProfissionalPagamentoRelatorioDTO`
 
 Erros são tratados no subscribe via callback de erro, exibindo mensagem genérica ao usuário.
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -36,6 +36,7 @@
 | Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
 | Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
 | Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença e vincular profissional responsável |
+| Relatórios | `/relatorios`, `/relatorios/pagamento-profissional` | Acessar relatórios administrativos e consultar pagamento de profissional por período |
 
 ---
 
@@ -57,7 +58,8 @@ carlessopilatesfe/
 │   │   │   │   ├── paciente-list/       # Listagem paginada de pacientes
 │   │   │   │   ├── paciente-form/       # Formulário de cadastro e edição
 │   │   │   │   └── paciente-detail/     # Visualização detalhada
-│   │   │   └── profissionais/           # CRUD de profissionais
+│   │   │   ├── profissionais/           # CRUD de profissionais
+│   │   │   └── relatorios/              # Relatórios administrativos
 │   │   ├── shared/
 │   │   │   └── components/
 │   │   │       └── confirmar-dialog/    # Componente de diálogo reutilizável
@@ -200,6 +202,37 @@ interface ProfissionalUpdateDTO {
 }
 ```
 
+### `ProfissionalPagamentoAulaDTO`
+Detalhamento de cada aula realizada usada no relatório de pagamento.
+```typescript
+interface ProfissionalPagamentoAulaDTO {
+  aulaId: number;
+  data: string;
+  pacienteId: number;
+  pacienteNome: string;
+  pagamentoId: number;
+  valorPagamento: number;
+  quantidadeAulasPagamento: number;
+  valorBaseAula: number;
+  percentualPagamentoAula: number;
+  valorProfissional: number;
+}
+```
+
+### `ProfissionalPagamentoRelatorioDTO`
+Retorno consolidado do relatório de pagamento de profissional.
+```typescript
+interface ProfissionalPagamentoRelatorioDTO {
+  profissionalId: number;
+  profissionalNome: string;
+  periodoInicio: string;
+  periodoFim: string;
+  totalAulas: number;
+  totalPagamento: number;
+  aulas: ProfissionalPagamentoAulaDTO[];
+}
+```
+
 Arquivo: `src/app/core/models/plano.ts`
 
 ### `AulaResponseDTO`
@@ -252,6 +285,21 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 | `atualizar(id, dto)` | `PUT /profissionais/{id}`    | Atualiza dados do profissional   |
 | `ativar(id)`      | `PATCH /profissionais/{id}/ativar` | Reativa profissional inativo  |
 | `inativar(id)`    | `PATCH /profissionais/{id}/inativar` | Inativa profissional          |
+| `relatorioPagamento(id, inicio, fim)` | `GET /profissionais/{id}/relatorio-pagamento?inicio&fim` | Consulta total devido e aulas realizadas no período |
+
+### Relatórios
+
+#### Pagamento de Profissional
+Rota: `/relatorios/pagamento-profissional`
+
+A tela carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige profissional, data inicial e data final, e valida que `inicio <= fim` antes de consultar a API.
+
+Contrato consumido:
+```http
+GET /profissionais/{id}/relatorio-pagamento?inicio=2025-02-01&fim=2025-02-28
+```
+
+O resultado apresenta profissional, período, total de aulas, total devido e uma tabela com o detalhamento de cada aula realizada.
 
 ### `AulaService`
 Arquivo: `src/app/core/services/aula.service.ts`
@@ -285,6 +333,8 @@ Os parâmetros numéricos das rotas são validados antes de qualquer chamada à 
 | `/profissionais/novo`    | `ProfissionalFormComponent` | Formulário de cadastro      |
 | `/profissionais/:id`     | `ProfissionalDetailComponent` | Detalhes do profissional  |
 | `/profissionais/:id/editar` | `ProfissionalFormComponent` | Formulário de edição     |
+| `/relatorios`            | `RelatorioListComponent` | Seção de relatórios          |
+| `/relatorios/pagamento-profissional` | `ProfissionalPagamentoRelatorioComponent` | Relatório de pagamento de profissional |
 
 ---
 
@@ -292,6 +342,8 @@ Os parâmetros numéricos das rotas são validados antes de qualquer chamada à 
 
 ### `AppComponent`
 - Navbar com link para "Pacientes"
+- Navbar com link para "Profissionais"
+- Navbar com link para "Relatórios"
 - `<router-outlet>` para renderização das páginas
 
 ### `PacienteListComponent`

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,6 +5,7 @@
   <ul class="navbar-menu">
     <li><a routerLink="/pacientes">Pacientes</a></li>
     <li><a routerLink="/profissionais">Profissionais</a></li>
+    <li><a routerLink="/relatorios">Relatórios</a></li>
   </ul>
 </nav>
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -28,6 +28,13 @@ describe('AppComponent', () => {
     expect(el.querySelector('.navbar-brand')?.textContent).toContain('Carlesso Pilates');
   });
 
+  it('should render relatorios navigation link', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('a[href="/relatorios"]')?.textContent).toContain('Relatórios');
+  });
+
   it('should contain a router-outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -48,6 +48,17 @@ export const routes: Routes = [
       import('./pages/aulas/aula-list/aula-list.component').then(m => m.AulaListComponent)
   },
   {
+    path: 'relatorios',
+    loadComponent: () =>
+      import('./pages/relatorios/relatorio-list/relatorio-list.component').then(m => m.RelatorioListComponent)
+  },
+  {
+    path: 'relatorios/pagamento-profissional',
+    loadComponent: () =>
+      import('./pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component')
+        .then(m => m.ProfissionalPagamentoRelatorioComponent)
+  },
+  {
     path: 'profissionais',
     loadComponent: () =>
       import('./pages/profissionais/profissional-list/profissional-list.component').then(m => m.ProfissionalListComponent)

--- a/src/app/core/models/profissional.ts
+++ b/src/app/core/models/profissional.ts
@@ -33,6 +33,29 @@ export interface ProfissionalUpdateDTO {
   dataInicio?: string;
 }
 
+export interface ProfissionalPagamentoAulaDTO {
+  aulaId: number;
+  data: string;
+  pacienteId: number;
+  pacienteNome: string;
+  pagamentoId: number;
+  valorPagamento: number;
+  quantidadeAulasPagamento: number;
+  valorBaseAula: number;
+  percentualPagamentoAula: number;
+  valorProfissional: number;
+}
+
+export interface ProfissionalPagamentoRelatorioDTO {
+  profissionalId: number;
+  profissionalNome: string;
+  periodoInicio: string;
+  periodoFim: string;
+  totalAulas: number;
+  totalPagamento: number;
+  aulas: ProfissionalPagamentoAulaDTO[];
+}
+
 export type ProfissionalPage = Page<ProfissionalResponseDTO>;
 
 export const TIPO_CONTRATO_LABEL: Record<TipoContrato, string> = {

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { ProfissionalService } from './profissional.service';
 import {
   ProfissionalPage,
+  ProfissionalPagamentoRelatorioDTO,
   ProfissionalRequestDTO,
   ProfissionalResponseDTO,
   ProfissionalUpdateDTO
@@ -23,6 +24,29 @@ const mockProfissional: ProfissionalResponseDTO = {
 const mockPage: ProfissionalPage = {
   content: [mockProfissional],
   page: { totalElements: 1, totalPages: 1, size: 10, number: 0 }
+};
+
+const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
+  profissionalId: 1,
+  profissionalNome: 'Paula Mendes',
+  periodoInicio: '2026-04-01',
+  periodoFim: '2026-04-30',
+  totalAulas: 1,
+  totalPagamento: 11.25,
+  aulas: [
+    {
+      aulaId: 10,
+      data: '2026-04-03',
+      pacienteId: 2,
+      pacienteNome: 'Ana Silva',
+      pagamentoId: 5,
+      valorPagamento: 200,
+      quantidadeAulasPagamento: 8,
+      valorBaseAula: 25,
+      percentualPagamentoAula: 45,
+      valorProfissional: 11.25
+    }
+  ]
 };
 
 describe('ProfissionalService', () => {
@@ -107,5 +131,16 @@ describe('ProfissionalService', () => {
     const req = httpMock.expectOne('/api/profissionais/1/inativar');
     expect(req.request.method).toBe('PATCH');
     req.flush(null);
+  });
+
+  it('should GET /api/profissionais/:id/relatorio-pagamento with period params', () => {
+    service.relatorioPagamento(1, '2026-04-01', '2026-04-30')
+      .subscribe(relatorio => expect(relatorio).toEqual(mockRelatorio));
+
+    const req = httpMock.expectOne(r => r.url === '/api/profissionais/1/relatorio-pagamento');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('inicio')).toBe('2026-04-01');
+    expect(req.request.params.get('fim')).toBe('2026-04-30');
+    req.flush(mockRelatorio);
   });
 });

--- a/src/app/core/services/profissional.service.ts
+++ b/src/app/core/services/profissional.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
   ProfissionalPage,
+  ProfissionalPagamentoRelatorioDTO,
   ProfissionalRequestDTO,
   ProfissionalResponseDTO,
   ProfissionalUpdateDTO
@@ -39,5 +40,10 @@ export class ProfissionalService {
 
   inativar(id: number): Observable<void> {
     return this.http.patch<void>(`${this.apiUrl}/${id}/inativar`, {});
+  }
+
+  relatorioPagamento(id: number, inicio: string, fim: string): Observable<ProfissionalPagamentoRelatorioDTO> {
+    const params = new HttpParams().set('inicio', inicio).set('fim', fim);
+    return this.http.get<ProfissionalPagamentoRelatorioDTO>(`${this.apiUrl}/${id}/relatorio-pagamento`, { params });
   }
 }

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.html
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.html
@@ -1,0 +1,104 @@
+<div class="page-header">
+  <h1>Pagamento de Profissional</h1>
+  <a routerLink="/relatorios" class="btn btn-outline">Voltar aos Relatórios</a>
+</div>
+
+<div *ngIf="erro" class="alert alert-danger">{{ erro }}</div>
+
+<form class="form-card relatorio-form" [formGroup]="form" (ngSubmit)="consultar()">
+  <div class="form-row">
+    <div class="form-group flex-3">
+      <label for="profissionalId">Profissional *</label>
+      <select id="profissionalId" formControlName="profissionalId" class="form-control"
+        [class.is-invalid]="form.get('profissionalId')?.invalid && form.get('profissionalId')?.touched">
+        <option [ngValue]="null">Selecione</option>
+        <option *ngFor="let profissional of profissionais" [ngValue]="profissional.id">
+          {{ profissional.nome }}
+        </option>
+      </select>
+      <div *ngIf="form.get('profissionalId')?.invalid && form.get('profissionalId')?.touched" class="invalid-feedback">
+        Selecione um profissional.
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="inicio">Início *</label>
+      <input id="inicio" type="date" formControlName="inicio" class="form-control"
+        [class.is-invalid]="form.get('inicio')?.invalid && form.get('inicio')?.touched" />
+      <div *ngIf="form.get('inicio')?.invalid && form.get('inicio')?.touched" class="invalid-feedback">
+        Informe a data inicial.
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="fim">Fim *</label>
+      <input id="fim" type="date" formControlName="fim" class="form-control"
+        [class.is-invalid]="form.get('fim')?.invalid && form.get('fim')?.touched" />
+      <div *ngIf="form.get('fim')?.invalid && form.get('fim')?.touched" class="invalid-feedback">
+        Informe a data final.
+      </div>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button type="submit" class="btn btn-primary" [disabled]="loadingProfissionais || loadingRelatorio">
+      Consultar
+    </button>
+  </div>
+</form>
+
+<div *ngIf="loadingProfissionais || loadingRelatorio" class="loading">Carregando...</div>
+
+<section *ngIf="relatorio" class="relatorio-resultado">
+  <div class="summary-grid">
+    <div class="summary-item">
+      <span class="label">Profissional</span>
+      <strong>{{ relatorio.profissionalNome }}</strong>
+    </div>
+    <div class="summary-item">
+      <span class="label">Período</span>
+      <strong>{{ relatorio.periodoInicio | date:'dd/MM/yyyy' }} a {{ relatorio.periodoFim | date:'dd/MM/yyyy' }}</strong>
+    </div>
+    <div class="summary-item">
+      <span class="label">Aulas</span>
+      <strong>{{ relatorio.totalAulas }}</strong>
+    </div>
+    <div class="summary-item">
+      <span class="label">Total devido</span>
+      <strong>{{ relatorio.totalPagamento | currency:'BRL' }}</strong>
+    </div>
+  </div>
+
+  <div *ngIf="relatorio.aulas.length === 0" class="empty-state">
+    Nenhuma aula realizada para o profissional no período informado.
+  </div>
+
+  <div *ngIf="relatorio.aulas.length > 0" class="table-responsive">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Data</th>
+          <th>Paciente</th>
+          <th>Pagamento</th>
+          <th>Valor do Pagamento</th>
+          <th>Aulas</th>
+          <th>Base por Aula</th>
+          <th>% Profissional</th>
+          <th>Valor Profissional</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let aula of relatorio.aulas">
+          <td>{{ aula.data | date:'dd/MM/yyyy' }}</td>
+          <td>{{ aula.pacienteNome }}</td>
+          <td>#{{ aula.pagamentoId }}</td>
+          <td>{{ aula.valorPagamento | currency:'BRL' }}</td>
+          <td>{{ aula.quantidadeAulasPagamento }}</td>
+          <td>{{ aula.valorBaseAula | currency:'BRL' }}</td>
+          <td>{{ aula.percentualPagamentoAula }}%</td>
+          <td>{{ aula.valorProfissional | currency:'BRL' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.scss
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.scss
@@ -1,0 +1,47 @@
+.relatorio-form {
+  margin-bottom: 1.25rem;
+}
+
+.relatorio-resultado {
+  margin-top: 1.25rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  padding: 1rem;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0,0,0,.08);
+
+  .label {
+    font-size: .78rem;
+    font-weight: 600;
+    color: var(--text-light);
+    text-transform: uppercase;
+  }
+
+  strong {
+    color: var(--text);
+  }
+}
+
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 760px) {
+  .form-row {
+    flex-direction: column;
+  }
+}

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.spec.ts
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.spec.ts
@@ -1,0 +1,124 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+import { ProfissionalPagamentoRelatorioComponent } from './profissional-pagamento-relatorio.component';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import {
+  ProfissionalPage,
+  ProfissionalPagamentoRelatorioDTO,
+  ProfissionalResponseDTO
+} from '../../../core/models/profissional';
+
+const mockProfissional: ProfissionalResponseDTO = {
+  id: 1,
+  nome: 'Paula Mendes',
+  email: 'paula@carlessopilates.com',
+  cpf: '123.456.111-00',
+  telefone: '(11) 98888-1111',
+  tipoContrato: 'PJ',
+  percentualPagamentoAula: 45,
+  dataInicio: '2024-01-15',
+  ativo: true
+};
+
+const mockPage: ProfissionalPage = {
+  content: [mockProfissional],
+  page: { totalElements: 1, totalPages: 1, size: 10, number: 0 }
+};
+
+const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
+  profissionalId: 1,
+  profissionalNome: 'Paula Mendes',
+  periodoInicio: '2026-04-01',
+  periodoFim: '2026-04-30',
+  totalAulas: 1,
+  totalPagamento: 11.25,
+  aulas: [
+    {
+      aulaId: 10,
+      data: '2026-04-03',
+      pacienteId: 2,
+      pacienteNome: 'Ana Silva',
+      pagamentoId: 5,
+      valorPagamento: 200,
+      quantidadeAulasPagamento: 8,
+      valorBaseAula: 25,
+      percentualPagamentoAula: 45,
+      valorProfissional: 11.25
+    }
+  ]
+};
+
+describe('ProfissionalPagamentoRelatorioComponent', () => {
+  let component: ProfissionalPagamentoRelatorioComponent;
+  let fixture: ComponentFixture<ProfissionalPagamentoRelatorioComponent>;
+  let serviceSpy: jasmine.SpyObj<ProfissionalService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ProfissionalService', ['listar', 'relatorioPagamento']);
+    serviceSpy.listar.and.returnValue(of(mockPage));
+    serviceSpy.relatorioPagamento.and.returnValue(of(mockRelatorio));
+
+    await TestBed.configureTestingModule({
+      imports: [ProfissionalPagamentoRelatorioComponent, RouterTestingModule],
+      providers: [{ provide: ProfissionalService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfissionalPagamentoRelatorioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load profissionais on init', () => {
+    expect(serviceSpy.listar).toHaveBeenCalledWith(0, 100);
+    expect(component.profissionais).toEqual([mockProfissional]);
+  });
+
+  it('should set erro when loading profissionais fails', () => {
+    serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
+
+    component.carregarProfissionais();
+
+    expect(component.erro).toBe('Erro ao carregar profissionais.');
+  });
+
+  it('should not request report when form is invalid', () => {
+    component.form.reset();
+
+    component.consultar();
+
+    expect(serviceSpy.relatorioPagamento).not.toHaveBeenCalled();
+  });
+
+  it('should validate period order before requesting report', () => {
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-30', fim: '2026-04-01' });
+
+    component.consultar();
+
+    expect(component.erro).toBe('A data inicial deve ser menor ou igual à data final.');
+    expect(serviceSpy.relatorioPagamento).not.toHaveBeenCalled();
+  });
+
+  it('should request report and store response', () => {
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-01', fim: '2026-04-30' });
+
+    component.consultar();
+
+    expect(serviceSpy.relatorioPagamento).toHaveBeenCalledWith(1, '2026-04-01', '2026-04-30');
+    expect(component.relatorio).toEqual(mockRelatorio);
+  });
+
+  it('should set erro when report request fails', () => {
+    serviceSpy.relatorioPagamento.and.returnValue(throwError(() => new Error('fail')));
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-01', fim: '2026-04-30' });
+
+    component.consultar();
+
+    expect(component.erro).toBe('Erro ao carregar relatório de pagamento.');
+    expect(component.loadingRelatorio).toBeFalse();
+  });
+});

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
@@ -1,0 +1,80 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { ProfissionalService } from '../../../core/services/profissional.service';
+import {
+  ProfissionalPagamentoRelatorioDTO,
+  ProfissionalResponseDTO
+} from '../../../core/models/profissional';
+
+@Component({
+  selector: 'app-profissional-pagamento-relatorio',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './profissional-pagamento-relatorio.component.html',
+  styleUrl: './profissional-pagamento-relatorio.component.scss'
+})
+export class ProfissionalPagamentoRelatorioComponent implements OnInit {
+  profissionais: ProfissionalResponseDTO[] = [];
+  form!: FormGroup;
+  relatorio: ProfissionalPagamentoRelatorioDTO | null = null;
+  loadingProfissionais = false;
+  loadingRelatorio = false;
+  erro: string | null = null;
+
+  constructor(
+    private profissionalService: ProfissionalService,
+    private fb: FormBuilder
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      profissionalId: [null, Validators.required],
+      inicio: ['', Validators.required],
+      fim: ['', Validators.required]
+    });
+    this.carregarProfissionais();
+  }
+
+  carregarProfissionais(): void {
+    this.loadingProfissionais = true;
+    this.profissionalService.listar(0, 100).subscribe({
+      next: page => {
+        this.profissionais = page.content;
+        this.loadingProfissionais = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar profissionais.';
+        this.loadingProfissionais = false;
+      }
+    });
+  }
+
+  consultar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const { profissionalId, inicio, fim } = this.form.value;
+    if (inicio > fim) {
+      this.erro = 'A data inicial deve ser menor ou igual à data final.';
+      this.relatorio = null;
+      return;
+    }
+
+    this.loadingRelatorio = true;
+    this.erro = null;
+    this.relatorio = null;
+    this.profissionalService.relatorioPagamento(Number(profissionalId), inicio, fim).subscribe({
+      next: relatorio => {
+        this.relatorio = relatorio;
+        this.loadingRelatorio = false;
+      },
+      error: () => {
+        this.erro = 'Erro ao carregar relatório de pagamento.';
+        this.loadingRelatorio = false;
+      }
+    });
+  }
+}

--- a/src/app/pages/relatorios/relatorio-list/relatorio-list.component.html
+++ b/src/app/pages/relatorios/relatorio-list/relatorio-list.component.html
@@ -1,0 +1,12 @@
+<div class="page-header">
+  <h1>Relatórios</h1>
+</div>
+
+<div class="relatorio-grid">
+  <a routerLink="/relatorios/pagamento-profissional" class="relatorio-card">
+    <span class="relatorio-card__title">Pagamento de Profissional</span>
+    <span class="relatorio-card__description">
+      Consulte aulas realizadas, valores por aula e total devido por período.
+    </span>
+  </a>
+</div>

--- a/src/app/pages/relatorios/relatorio-list/relatorio-list.component.scss
+++ b/src/app/pages/relatorios/relatorio-list/relatorio-list.component.scss
@@ -1,0 +1,33 @@
+.relatorio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.relatorio-card {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  min-height: 120px;
+  padding: 1rem;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0,0,0,.08);
+
+  &:hover {
+    border-color: var(--primary);
+  }
+
+  &__title {
+    font-weight: 700;
+    color: var(--primary);
+  }
+
+  &__description {
+    color: var(--text-light);
+    line-height: 1.35;
+  }
+}

--- a/src/app/pages/relatorios/relatorio-list/relatorio-list.component.spec.ts
+++ b/src/app/pages/relatorios/relatorio-list/relatorio-list.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RelatorioListComponent } from './relatorio-list.component';
+
+describe('RelatorioListComponent', () => {
+  let fixture: ComponentFixture<RelatorioListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RelatorioListComponent, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RelatorioListComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render professional payment report link', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const link = el.querySelector('a[href="/relatorios/pagamento-profissional"]');
+
+    expect(link).toBeTruthy();
+    expect(link?.textContent).toContain('Pagamento de Profissional');
+  });
+});

--- a/src/app/pages/relatorios/relatorio-list/relatorio-list.component.ts
+++ b/src/app/pages/relatorios/relatorio-list/relatorio-list.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-relatorio-list',
+  imports: [RouterLink],
+  templateUrl: './relatorio-list.component.html',
+  styleUrl: './relatorio-list.component.scss'
+})
+export class RelatorioListComponent {}


### PR DESCRIPTION
## Resumo
- Cria a seção `/relatorios` e adiciona link no menu principal.
- Implementa o relatório `/relatorios/pagamento-profissional` com seleção de profissional, período obrigatório, validação de datas e tabela detalhada por aula.
- Adiciona DTOs e integração com `GET /profissionais/{id}/relatorio-pagamento?inicio&fim`.
- Atualiza README e documentação do projeto.

## Testes
- `npm test -- --watch=false --browsers=ChromeHeadless` — 194 testes passando
- `npm run build`

Closes #35