### PR TITLE
feat: exporta relatório de pagamento do profissional

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Arquivos de teste:
 | **Planos** | Criação de planos (mensal/trimestral/anual) com frequência semanal e seleção de dias |
 | **Pagamentos** | Registro e confirmação de pagamentos; geração de aulas é automática no backend |
 | **Aulas** | Visualização das aulas geradas e confirmação de presença com vínculo do profissional responsável |
-| **Relatórios** | Seção administrativa com relatório de pagamento de profissional por período |
+| **Relatórios** | Seção administrativa com relatório de pagamento de profissional por período e exportação em PDF/XLSX |
 
 ---
 
@@ -169,7 +169,7 @@ As rotas que recebem identificadores numéricos validam os parâmetros antes de 
 
 A tela de aulas carrega os profissionais ativos e exige a seleção do profissional antes de marcar uma aula pendente como realizada. A confirmação envia `PATCH /aulas/{id}/realizar?profissionalId={id}`; aulas já realizadas exibem o profissional vinculado quando retornado pela API.
 
-O relatório de pagamento de profissional carrega os profissionais ativos para seleção, exige período inicial e final, valida que a data inicial não seja posterior à final e consulta `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. O resultado exibe totais consolidados e detalhamento por aula realizada.
+O relatório de pagamento de profissional carrega os profissionais ativos para seleção, exige período inicial e final, valida que a data inicial não seja posterior à final e consulta `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. O resultado exibe totais consolidados, resumo por pagamento e detalhamento por aula realizada. A mesma tela exporta o relatório em PDF e Excel/XLSX pelos endpoints `GET /profissionais/{id}/relatorio-pagamento/pdf?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` e `GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`, tratando a resposta como `Blob`, usando o nome retornado em `Content-Disposition` quando disponível e bloqueando novos cliques enquanto o arquivo é gerado.
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -29,8 +29,9 @@ O projeto está em fase inicial de desenvolvimento (**MVP**). Commits realizados
 15. Correção da navegação de páginas na listagem de profissionais para ignorar páginas negativas, fora do total retornado ou iguais à página atual
 16. Implementação da confirmação de aula realizada com seleção e vínculo do profissional responsável
 17. Criação da seção de relatórios e do relatório de pagamento de profissional por período
+18. Adição da exportação do relatório de pagamento de profissional em PDF e Excel/XLSX
 
-A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A tela de aulas permite marcar uma aula como realizada somente após selecionar o profissional responsável, enviando esse vínculo para o backend. A seção de relatórios já possui consulta de pagamento de profissional por período, com seleção de profissional ativo, validação de datas e detalhamento por aula realizada. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
+A funcionalidade central de **gestão de pacientes** está operacional, incluindo filtros de busca, paginação server-side com tamanho de página configurável na listagem e cobertura de testes unitários para o serviço e todos os componentes de página. A listagem de profissionais também usa paginação server-side, limita os botões visíveis a uma janela de 5 páginas e bloqueia navegação para páginas inválidas ou repetidas. A tela de aulas permite marcar uma aula como realizada somente após selecionar o profissional responsável, enviando esse vínculo para o backend. A seção de relatórios já possui consulta de pagamento de profissional por período, com seleção de profissional ativo, validação de datas, resumo por pagamento, detalhamento por aula realizada e exportação em PDF/XLSX. A aplicação agora pode ser executada em container Docker. Ainda não há autenticação.
 
 ---
 
@@ -58,7 +59,9 @@ O cadastro de profissionais segue o contrato do backend para atualização via `
 A confirmação de presença em aulas usa `PATCH /aulas/{id}/realizar?profissionalId={id}`. O frontend carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige seleção antes de confirmar e exibe o profissional retornado em aulas já realizadas.
 
 ### Relatório de pagamento de profissional
-O relatório usa `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. A tela valida seleção de profissional, datas obrigatórias e impede consulta quando a data inicial é posterior à final. O retorno consolida total de aulas, total devido e detalhamento por aula, incluindo paciente, pagamento, valor base por aula, percentual do profissional e valor devido.
+O relatório usa `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. A tela valida seleção de profissional, datas obrigatórias e impede consulta quando a data inicial é posterior à final. O retorno usa o contrato estruturado da API com `profissional`, `periodo`, `resumo`, `pagamentos`, `aulas` e `geradoEm`, consolidando total de aulas, total devido, agrupamento por pagamento e detalhamento por aula.
+
+A exportação usa os endpoints `GET /profissionais/{id}/relatorio-pagamento/pdf?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` e `GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=YYYY-MM-DD&fim=YYYY-MM-DD`. O frontend solicita a resposta como `Blob`, observa os headers HTTP, usa o nome retornado em `Content-Disposition` quando disponível e bloqueia os botões de exportação durante a geração do arquivo.
 
 ### Proxy de desenvolvimento para CORS
 O browser bloqueia requisições cross-origin de `localhost:4200` para `localhost:8080`. A solução adotada foi o proxy do Angular CLI: `proxy.conf.json` redireciona `/api/*` para `http://localhost:8080/*` no lado do servidor, eliminando o problema de CORS em desenvolvimento. O `PacienteService` usa a URL relativa `/api/pacientes`.
@@ -118,7 +121,7 @@ A configuração por `environment.ts` ainda não é necessária porque o fronten
 | Agendamentos   | Vínculo paciente ↔ aula ↔ data/hora           |
 | Frequência     | Controle de presença por sessão               |
 | Financeiro     | Planos, pagamentos e cobranças                |
-| Relatórios     | Relatório de pagamento de profissional por período; futuros dashboards e métricas do estúdio |
+| Relatórios     | Relatório de pagamento de profissional por período com exportação PDF/XLSX; futuros dashboards e métricas do estúdio |
 
 ---
 
@@ -154,6 +157,8 @@ A API segue o padrão REST. O frontend espera os seguintes contratos:
 - `PATCH /profissionais/{id}/ativar` → `204 No Content`
 - `PATCH /profissionais/{id}/inativar` → `204 No Content`
 - `GET /profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` → `ProfissionalPagamentoRelatorioDTO`
+- `GET /profissionais/{id}/relatorio-pagamento/pdf?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` → `application/pdf` com `Content-Disposition: attachment`
+- `GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` → `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` com `Content-Disposition: attachment`
 
 Erros são tratados no subscribe via callback de erro, exibindo mensagem genérica ao usuário.
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -36,7 +36,7 @@
 | Planos | `/planos/paciente/:pacienteId`, `/planos/novo/:pacienteId` | Listar, criar (com seleção de dias e validação de frequência), inativar |
 | Pagamentos | `/pagamentos/paciente/:pacienteId`, `/pagamentos/novo/:pacienteId` | Listar, criar, confirmar pagamento |
 | Aulas | `/aulas/paciente/:pacienteId`, `/aulas/pagamento/:pagamentoId` | Listar, confirmar presença e vincular profissional responsável |
-| Relatórios | `/relatorios`, `/relatorios/pagamento-profissional` | Acessar relatórios administrativos e consultar pagamento de profissional por período |
+| Relatórios | `/relatorios`, `/relatorios/pagamento-profissional` | Acessar relatórios administrativos, consultar pagamento de profissional por período e exportar PDF/XLSX |
 
 ---
 
@@ -220,16 +220,44 @@ interface ProfissionalPagamentoAulaDTO {
 ```
 
 ### `ProfissionalPagamentoRelatorioDTO`
-Retorno consolidado do relatório de pagamento de profissional.
+Retorno consolidado do relatório de pagamento de profissional, usando o contrato estruturado da API.
 ```typescript
-interface ProfissionalPagamentoRelatorioDTO {
-  profissionalId: number;
-  profissionalNome: string;
-  periodoInicio: string;
-  periodoFim: string;
+interface ProfissionalResumoDTO {
+  id: number;
+  nome: string;
+  cpf: string;
+  tipoContrato: 'CLT' | 'PJ' | 'AUTONOMO';
+  percentualPagamentoAula: number;
+}
+
+interface ProfissionalPagamentoPeriodoDTO {
+  inicio: string;
+  fim: string;
+}
+
+interface ProfissionalPagamentoResumoFinanceiroDTO {
   totalAulas: number;
-  totalPagamento: number;
+  quantidadePagamentos: number;
+  totalPagamentosBruto: number;
+  totalProfissional: number;
+}
+
+interface ProfissionalPagamentoResumoDTO {
+  pagamentoId: number;
+  valorPagamento: number;
+  quantidadeAulasPagamento: number;
+  quantidadeAulasNoPeriodo: number;
+  valorBaseAula: number;
+  totalProfissional: number;
+}
+
+interface ProfissionalPagamentoRelatorioDTO {
+  profissional: ProfissionalResumoDTO;
+  periodo: ProfissionalPagamentoPeriodoDTO;
+  resumo: ProfissionalPagamentoResumoFinanceiroDTO;
+  pagamentos: ProfissionalPagamentoResumoDTO[];
   aulas: ProfissionalPagamentoAulaDTO[];
+  geradoEm: string;
 }
 ```
 
@@ -286,6 +314,8 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 | `ativar(id)`      | `PATCH /profissionais/{id}/ativar` | Reativa profissional inativo  |
 | `inativar(id)`    | `PATCH /profissionais/{id}/inativar` | Inativa profissional          |
 | `relatorioPagamento(id, inicio, fim)` | `GET /profissionais/{id}/relatorio-pagamento?inicio&fim` | Consulta total devido e aulas realizadas no período |
+| `exportarRelatorioPagamentoProfissionalPdf(id, inicio, fim)` | `GET /profissionais/{id}/relatorio-pagamento/pdf?inicio&fim` | Baixa o relatório em PDF como `Blob` |
+| `exportarRelatorioPagamentoProfissionalExcel(id, inicio, fim)` | `GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio&fim` | Baixa o relatório em Excel/XLSX como `Blob` |
 
 ### Relatórios
 
@@ -294,12 +324,20 @@ Rota: `/relatorios/pagamento-profissional`
 
 A tela carrega profissionais ativos via `GET /profissionais?page=0&size=100&sort=nome`, exige profissional, data inicial e data final, e valida que `inicio <= fim` antes de consultar a API.
 
-Contrato consumido:
+Contrato JSON consumido:
 ```http
 GET /profissionais/{id}/relatorio-pagamento?inicio=2025-02-01&fim=2025-02-28
 ```
 
-O resultado apresenta profissional, período, total de aulas, total devido e uma tabela com o detalhamento de cada aula realizada.
+O resultado apresenta profissional, período, total de aulas, total devido, total bruto, resumo por pagamento e uma tabela com o detalhamento de cada aula realizada.
+
+Contratos de exportação:
+```http
+GET /profissionais/{id}/relatorio-pagamento/pdf?inicio=2025-02-01&fim=2025-02-28
+GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=2025-02-01&fim=2025-02-28
+```
+
+As exportações são requisitadas com `responseType: 'blob'` e `observe: 'response'`. O frontend usa o header `Content-Disposition` para preservar o nome de arquivo definido pelo backend e aplica fallback local quando o header não está disponível. Os botões de exportação ficam bloqueados durante a geração do arquivo e erros exibem mensagem amigável na tela.
 
 ### `AulaService`
 Arquivo: `src/app/core/services/aula.service.ts`

--- a/src/app/core/models/profissional.ts
+++ b/src/app/core/models/profissional.ts
@@ -46,14 +46,42 @@ export interface ProfissionalPagamentoAulaDTO {
   valorProfissional: number;
 }
 
-export interface ProfissionalPagamentoRelatorioDTO {
-  profissionalId: number;
-  profissionalNome: string;
-  periodoInicio: string;
-  periodoFim: string;
+export interface ProfissionalResumoDTO {
+  id: number;
+  nome: string;
+  cpf: string;
+  tipoContrato: TipoContrato;
+  percentualPagamentoAula: number;
+}
+
+export interface ProfissionalPagamentoPeriodoDTO {
+  inicio: string;
+  fim: string;
+}
+
+export interface ProfissionalPagamentoResumoFinanceiroDTO {
   totalAulas: number;
-  totalPagamento: number;
+  quantidadePagamentos: number;
+  totalPagamentosBruto: number;
+  totalProfissional: number;
+}
+
+export interface ProfissionalPagamentoResumoDTO {
+  pagamentoId: number;
+  valorPagamento: number;
+  quantidadeAulasPagamento: number;
+  quantidadeAulasNoPeriodo: number;
+  valorBaseAula: number;
+  totalProfissional: number;
+}
+
+export interface ProfissionalPagamentoRelatorioDTO {
+  profissional: ProfissionalResumoDTO;
+  periodo: ProfissionalPagamentoPeriodoDTO;
+  resumo: ProfissionalPagamentoResumoFinanceiroDTO;
+  pagamentos: ProfissionalPagamentoResumoDTO[];
   aulas: ProfissionalPagamentoAulaDTO[];
+  geradoEm: string;
 }
 
 export type ProfissionalPage = Page<ProfissionalResponseDTO>;

--- a/src/app/core/services/profissional.service.spec.ts
+++ b/src/app/core/services/profissional.service.spec.ts
@@ -27,12 +27,30 @@ const mockPage: ProfissionalPage = {
 };
 
 const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
-  profissionalId: 1,
-  profissionalNome: 'Paula Mendes',
-  periodoInicio: '2026-04-01',
-  periodoFim: '2026-04-30',
-  totalAulas: 1,
-  totalPagamento: 11.25,
+  profissional: {
+    id: 1,
+    nome: 'Paula Mendes',
+    cpf: '123.456.111-00',
+    tipoContrato: 'PJ',
+    percentualPagamentoAula: 45
+  },
+  periodo: { inicio: '2026-04-01', fim: '2026-04-30' },
+  resumo: {
+    totalAulas: 1,
+    quantidadePagamentos: 1,
+    totalPagamentosBruto: 200,
+    totalProfissional: 11.25
+  },
+  pagamentos: [
+    {
+      pagamentoId: 5,
+      valorPagamento: 200,
+      quantidadeAulasPagamento: 8,
+      quantidadeAulasNoPeriodo: 1,
+      valorBaseAula: 25,
+      totalProfissional: 11.25
+    }
+  ],
   aulas: [
     {
       aulaId: 10,
@@ -46,7 +64,8 @@ const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
       percentualPagamentoAula: 45,
       valorProfissional: 11.25
     }
-  ]
+  ],
+  geradoEm: '2026-04-27T10:00:00'
 };
 
 describe('ProfissionalService', () => {
@@ -142,5 +161,35 @@ describe('ProfissionalService', () => {
     expect(req.request.params.get('inicio')).toBe('2026-04-01');
     expect(req.request.params.get('fim')).toBe('2026-04-30');
     req.flush(mockRelatorio);
+  });
+
+  it('should GET PDF report export as blob observing response', () => {
+    const blob = new Blob(['pdf'], { type: 'application/pdf' });
+
+    service.exportarRelatorioPagamentoProfissionalPdf(1, '2026-04-01', '2026-04-30')
+      .subscribe(response => expect(response.body).toBe(blob));
+
+    const req = httpMock.expectOne(r => r.url === '/api/profissionais/1/relatorio-pagamento/pdf');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('inicio')).toBe('2026-04-01');
+    expect(req.request.params.get('fim')).toBe('2026-04-30');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(blob);
+  });
+
+  it('should GET XLSX report export as blob observing response', () => {
+    const blob = new Blob(['xlsx'], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    });
+
+    service.exportarRelatorioPagamentoProfissionalExcel(1, '2026-04-01', '2026-04-30')
+      .subscribe(response => expect(response.body).toBe(blob));
+
+    const req = httpMock.expectOne(r => r.url === '/api/profissionais/1/relatorio-pagamento/xlsx');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('inicio')).toBe('2026-04-01');
+    expect(req.request.params.get('fim')).toBe('2026-04-30');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(blob);
   });
 });

--- a/src/app/core/services/profissional.service.ts
+++ b/src/app/core/services/profissional.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
   ProfissionalPage,
@@ -45,5 +45,27 @@ export class ProfissionalService {
   relatorioPagamento(id: number, inicio: string, fim: string): Observable<ProfissionalPagamentoRelatorioDTO> {
     const params = new HttpParams().set('inicio', inicio).set('fim', fim);
     return this.http.get<ProfissionalPagamentoRelatorioDTO>(`${this.apiUrl}/${id}/relatorio-pagamento`, { params });
+  }
+
+  exportarRelatorioPagamentoProfissionalPdf(id: number, inicio: string, fim: string): Observable<HttpResponse<Blob>> {
+    return this.exportarRelatorioPagamentoProfissional(id, inicio, fim, 'pdf');
+  }
+
+  exportarRelatorioPagamentoProfissionalExcel(id: number, inicio: string, fim: string): Observable<HttpResponse<Blob>> {
+    return this.exportarRelatorioPagamentoProfissional(id, inicio, fim, 'xlsx');
+  }
+
+  private exportarRelatorioPagamentoProfissional(
+    id: number,
+    inicio: string,
+    fim: string,
+    formato: 'pdf' | 'xlsx'
+  ): Observable<HttpResponse<Blob>> {
+    const params = new HttpParams().set('inicio', inicio).set('fim', fim);
+    return this.http.get(`${this.apiUrl}/${id}/relatorio-pagamento/${formato}`, {
+      params,
+      observe: 'response',
+      responseType: 'blob'
+    });
   }
 }

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.html
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.html
@@ -44,29 +44,72 @@
     <button type="submit" class="btn btn-primary" [disabled]="loadingProfissionais || loadingRelatorio">
       Consultar
     </button>
+    <button type="button" class="btn btn-secondary" (click)="exportarPdf()"
+      [disabled]="loadingProfissionais || loadingRelatorio || exportandoPdf || exportandoExcel">
+      {{ exportandoPdf ? 'Gerando PDF...' : 'Exportar PDF' }}
+    </button>
+    <button type="button" class="btn btn-secondary" (click)="exportarExcel()"
+      [disabled]="loadingProfissionais || loadingRelatorio || exportandoPdf || exportandoExcel">
+      {{ exportandoExcel ? 'Gerando Excel...' : 'Exportar Excel' }}
+    </button>
   </div>
 </form>
 
-<div *ngIf="loadingProfissionais || loadingRelatorio" class="loading">Carregando...</div>
+<div *ngIf="loadingProfissionais || loadingRelatorio || exportandoPdf || exportandoExcel" class="loading">
+  {{ exportandoPdf || exportandoExcel ? 'Gerando arquivo...' : 'Carregando...' }}
+</div>
 
 <section *ngIf="relatorio" class="relatorio-resultado">
   <div class="summary-grid">
     <div class="summary-item">
       <span class="label">Profissional</span>
-      <strong>{{ relatorio.profissionalNome }}</strong>
+      <strong>{{ relatorio.profissional.nome }}</strong>
     </div>
     <div class="summary-item">
       <span class="label">Período</span>
-      <strong>{{ relatorio.periodoInicio | date:'dd/MM/yyyy' }} a {{ relatorio.periodoFim | date:'dd/MM/yyyy' }}</strong>
+      <strong>{{ relatorio.periodo.inicio | date:'dd/MM/yyyy' }} a {{ relatorio.periodo.fim | date:'dd/MM/yyyy' }}</strong>
     </div>
     <div class="summary-item">
       <span class="label">Aulas</span>
-      <strong>{{ relatorio.totalAulas }}</strong>
+      <strong>{{ relatorio.resumo.totalAulas }}</strong>
     </div>
     <div class="summary-item">
       <span class="label">Total devido</span>
-      <strong>{{ relatorio.totalPagamento | currency:'BRL' }}</strong>
+      <strong>{{ relatorio.resumo.totalProfissional | currency:'BRL' }}</strong>
     </div>
+    <div class="summary-item">
+      <span class="label">Pagamentos</span>
+      <strong>{{ relatorio.resumo.quantidadePagamentos }}</strong>
+    </div>
+    <div class="summary-item">
+      <span class="label">Bruto no período</span>
+      <strong>{{ relatorio.resumo.totalPagamentosBruto | currency:'BRL' }}</strong>
+    </div>
+  </div>
+
+  <div *ngIf="relatorio.pagamentos.length > 0" class="table-responsive pagamentos-resumo">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Pagamento</th>
+          <th>Valor do Pagamento</th>
+          <th>Aulas do Pagamento</th>
+          <th>Aulas no Período</th>
+          <th>Base por Aula</th>
+          <th>Total Profissional</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let pagamento of relatorio.pagamentos">
+          <td>#{{ pagamento.pagamentoId }}</td>
+          <td>{{ pagamento.valorPagamento | currency:'BRL' }}</td>
+          <td>{{ pagamento.quantidadeAulasPagamento }}</td>
+          <td>{{ pagamento.quantidadeAulasNoPeriodo }}</td>
+          <td>{{ pagamento.valorBaseAula | currency:'BRL' }}</td>
+          <td>{{ pagamento.totalProfissional | currency:'BRL' }}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 
   <div *ngIf="relatorio.aulas.length === 0" class="empty-state">

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.scss
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.scss
@@ -40,8 +40,16 @@
   overflow-x: auto;
 }
 
+.pagamentos-resumo {
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 760px) {
   .form-row {
+    flex-direction: column;
+  }
+
+  .form-actions {
     flex-direction: column;
   }
 }

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.spec.ts
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of, throwError } from 'rxjs';
 import { ProfissionalPagamentoRelatorioComponent } from './profissional-pagamento-relatorio.component';
@@ -27,12 +28,30 @@ const mockPage: ProfissionalPage = {
 };
 
 const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
-  profissionalId: 1,
-  profissionalNome: 'Paula Mendes',
-  periodoInicio: '2026-04-01',
-  periodoFim: '2026-04-30',
-  totalAulas: 1,
-  totalPagamento: 11.25,
+  profissional: {
+    id: 1,
+    nome: 'Paula Mendes',
+    cpf: '123.456.111-00',
+    tipoContrato: 'PJ',
+    percentualPagamentoAula: 45
+  },
+  periodo: { inicio: '2026-04-01', fim: '2026-04-30' },
+  resumo: {
+    totalAulas: 1,
+    quantidadePagamentos: 1,
+    totalPagamentosBruto: 200,
+    totalProfissional: 11.25
+  },
+  pagamentos: [
+    {
+      pagamentoId: 5,
+      valorPagamento: 200,
+      quantidadeAulasPagamento: 8,
+      quantidadeAulasNoPeriodo: 1,
+      valorBaseAula: 25,
+      totalProfissional: 11.25
+    }
+  ],
   aulas: [
     {
       aulaId: 10,
@@ -46,8 +65,25 @@ const mockRelatorio: ProfissionalPagamentoRelatorioDTO = {
       percentualPagamentoAula: 45,
       valorProfissional: 11.25
     }
-  ]
+  ],
+  geradoEm: '2026-04-27T10:00:00'
 };
+
+const mockPdfResponse = new HttpResponse({
+  body: new Blob(['pdf'], { type: 'application/pdf' }),
+  headers: new HttpHeaders({
+    'Content-Disposition': 'attachment; filename="relatorio.pdf"'
+  })
+});
+
+const mockExcelResponse = new HttpResponse({
+  body: new Blob(['xlsx'], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  }),
+  headers: new HttpHeaders({
+    'Content-Disposition': 'attachment; filename="relatorio.xlsx"'
+  })
+});
 
 describe('ProfissionalPagamentoRelatorioComponent', () => {
   let component: ProfissionalPagamentoRelatorioComponent;
@@ -55,9 +91,16 @@ describe('ProfissionalPagamentoRelatorioComponent', () => {
   let serviceSpy: jasmine.SpyObj<ProfissionalService>;
 
   beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('ProfissionalService', ['listar', 'relatorioPagamento']);
+    serviceSpy = jasmine.createSpyObj('ProfissionalService', [
+      'listar',
+      'relatorioPagamento',
+      'exportarRelatorioPagamentoProfissionalPdf',
+      'exportarRelatorioPagamentoProfissionalExcel'
+    ]);
     serviceSpy.listar.and.returnValue(of(mockPage));
     serviceSpy.relatorioPagamento.and.returnValue(of(mockRelatorio));
+    serviceSpy.exportarRelatorioPagamentoProfissionalPdf.and.returnValue(of(mockPdfResponse));
+    serviceSpy.exportarRelatorioPagamentoProfissionalExcel.and.returnValue(of(mockExcelResponse));
 
     await TestBed.configureTestingModule({
       imports: [ProfissionalPagamentoRelatorioComponent, RouterTestingModule],
@@ -120,5 +163,60 @@ describe('ProfissionalPagamentoRelatorioComponent', () => {
 
     expect(component.erro).toBe('Erro ao carregar relatório de pagamento.');
     expect(component.loadingRelatorio).toBeFalse();
+  });
+
+  it('should not export when form is invalid', () => {
+    component.form.reset();
+
+    component.exportarPdf();
+    component.exportarExcel();
+
+    expect(serviceSpy.exportarRelatorioPagamentoProfissionalPdf).not.toHaveBeenCalled();
+    expect(serviceSpy.exportarRelatorioPagamentoProfissionalExcel).not.toHaveBeenCalled();
+  });
+
+  it('should validate period order before exporting', () => {
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-30', fim: '2026-04-01' });
+
+    component.exportarPdf();
+
+    expect(component.erro).toBe('A data inicial deve ser menor ou igual à data final.');
+    expect(serviceSpy.exportarRelatorioPagamentoProfissionalPdf).not.toHaveBeenCalled();
+  });
+
+  it('should export PDF and reset loading state', () => {
+    spyOn(window.URL, 'createObjectURL').and.returnValue('blob:relatorio-pdf');
+    spyOn(window.URL, 'revokeObjectURL');
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-01', fim: '2026-04-30' });
+
+    component.exportarPdf();
+
+    expect(serviceSpy.exportarRelatorioPagamentoProfissionalPdf)
+      .toHaveBeenCalledWith(1, '2026-04-01', '2026-04-30');
+    expect(component.exportandoPdf).toBeFalse();
+    expect(component.erro).toBeNull();
+  });
+
+  it('should export Excel and reset loading state', () => {
+    spyOn(window.URL, 'createObjectURL').and.returnValue('blob:relatorio-xlsx');
+    spyOn(window.URL, 'revokeObjectURL');
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-01', fim: '2026-04-30' });
+
+    component.exportarExcel();
+
+    expect(serviceSpy.exportarRelatorioPagamentoProfissionalExcel)
+      .toHaveBeenCalledWith(1, '2026-04-01', '2026-04-30');
+    expect(component.exportandoExcel).toBeFalse();
+    expect(component.erro).toBeNull();
+  });
+
+  it('should set friendly error when PDF export fails', () => {
+    serviceSpy.exportarRelatorioPagamentoProfissionalPdf.and.returnValue(throwError(() => new Error('fail')));
+    component.form.setValue({ profissionalId: 1, inicio: '2026-04-01', fim: '2026-04-30' });
+
+    component.exportarPdf();
+
+    expect(component.erro).toBe('Erro ao exportar relatório em PDF.');
+    expect(component.exportandoPdf).toBeFalse();
   });
 });

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
@@ -111,8 +111,13 @@ export class ProfissionalPagamentoRelatorioComponent implements OnInit {
     this.erro = null;
     request$.subscribe({
       next: response => {
-        baixarBlob(response, fallbackNomeArquivo);
-        this.setExportando(formato, false);
+        try {
+          baixarBlob(response, fallbackNomeArquivo);
+        } catch {
+          this.erro = `Erro ao exportar relatório em ${formato === 'pdf' ? 'PDF' : 'Excel'}.`;
+        } finally {
+          this.setExportando(formato, false);
+        }
       },
       error: () => {
         this.erro = `Erro ao exportar relatório em ${formato === 'pdf' ? 'PDF' : 'Excel'}.`;

--- a/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
+++ b/src/app/pages/relatorios/profissional-pagamento-relatorio/profissional-pagamento-relatorio.component.ts
@@ -7,6 +7,7 @@ import {
   ProfissionalPagamentoRelatorioDTO,
   ProfissionalResponseDTO
 } from '../../../core/models/profissional';
+import { baixarBlob } from '../../../shared/utils/file-download';
 
 @Component({
   selector: 'app-profissional-pagamento-relatorio',
@@ -20,6 +21,8 @@ export class ProfissionalPagamentoRelatorioComponent implements OnInit {
   relatorio: ProfissionalPagamentoRelatorioDTO | null = null;
   loadingProfissionais = false;
   loadingRelatorio = false;
+  exportandoPdf = false;
+  exportandoExcel = false;
   erro: string | null = null;
 
   constructor(
@@ -76,5 +79,54 @@ export class ProfissionalPagamentoRelatorioComponent implements OnInit {
         this.loadingRelatorio = false;
       }
     });
+  }
+
+  exportarPdf(): void {
+    this.exportar('pdf');
+  }
+
+  exportarExcel(): void {
+    this.exportar('xlsx');
+  }
+
+  private exportar(formato: 'pdf' | 'xlsx'): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const { profissionalId, inicio, fim } = this.form.value;
+    if (inicio > fim) {
+      this.erro = 'A data inicial deve ser menor ou igual à data final.';
+      return;
+    }
+
+    const id = Number(profissionalId);
+    const fallbackNomeArquivo = `relatorio-pagamento-profissional-${id}-${inicio}-${fim}.${formato}`;
+    const request$ = formato === 'pdf'
+      ? this.profissionalService.exportarRelatorioPagamentoProfissionalPdf(id, inicio, fim)
+      : this.profissionalService.exportarRelatorioPagamentoProfissionalExcel(id, inicio, fim);
+
+    this.setExportando(formato, true);
+    this.erro = null;
+    request$.subscribe({
+      next: response => {
+        baixarBlob(response, fallbackNomeArquivo);
+        this.setExportando(formato, false);
+      },
+      error: () => {
+        this.erro = `Erro ao exportar relatório em ${formato === 'pdf' ? 'PDF' : 'Excel'}.`;
+        this.setExportando(formato, false);
+      }
+    });
+  }
+
+  private setExportando(formato: 'pdf' | 'xlsx', exportando: boolean): void {
+    if (formato === 'pdf') {
+      this.exportandoPdf = exportando;
+      return;
+    }
+
+    this.exportandoExcel = exportando;
   }
 }

--- a/src/app/shared/utils/file-download.spec.ts
+++ b/src/app/shared/utils/file-download.spec.ts
@@ -17,6 +17,24 @@ describe('file-download utils', () => {
     expect(nome).toBe('relatorio pagamento.xlsx');
   });
 
+  it('should extract UTF-8 filename with language tag from Content-Disposition', () => {
+    const nome = extrairNomeArquivo(
+      "attachment; filename*=UTF-8'pt-BR'relatorio%20pagamento.xlsx",
+      'fallback.xlsx'
+    );
+
+    expect(nome).toBe('relatorio pagamento.xlsx');
+  });
+
+  it('should use fallback filename when UTF-8 filename is malformed', () => {
+    const nome = extrairNomeArquivo(
+      "attachment; filename*=UTF-8''relatorio%ZZ.pdf",
+      'fallback.pdf'
+    );
+
+    expect(nome).toBe('fallback.pdf');
+  });
+
   it('should use fallback filename when header is missing', () => {
     expect(extrairNomeArquivo(null, 'fallback.pdf')).toBe('fallback.pdf');
   });

--- a/src/app/shared/utils/file-download.spec.ts
+++ b/src/app/shared/utils/file-download.spec.ts
@@ -1,0 +1,45 @@
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { baixarBlob, extrairNomeArquivo } from './file-download';
+
+describe('file-download utils', () => {
+  it('should extract quoted filename from Content-Disposition', () => {
+    const nome = extrairNomeArquivo('attachment; filename="relatorio.pdf"', 'fallback.pdf');
+
+    expect(nome).toBe('relatorio.pdf');
+  });
+
+  it('should extract UTF-8 filename from Content-Disposition', () => {
+    const nome = extrairNomeArquivo(
+      "attachment; filename*=UTF-8''relatorio%20pagamento.xlsx",
+      'fallback.xlsx'
+    );
+
+    expect(nome).toBe('relatorio pagamento.xlsx');
+  });
+
+  it('should use fallback filename when header is missing', () => {
+    expect(extrairNomeArquivo(null, 'fallback.pdf')).toBe('fallback.pdf');
+  });
+
+  it('should create object URL and trigger download for blob response', () => {
+    const blob = new Blob(['pdf'], { type: 'application/pdf' });
+    const response = new HttpResponse({
+      body: blob,
+      headers: new HttpHeaders({
+        'Content-Disposition': 'attachment; filename="relatorio.pdf"'
+      })
+    });
+    const anchor = document.createElement('a');
+    spyOn(document, 'createElement').and.returnValue(anchor);
+    spyOn(anchor, 'click');
+    spyOn(window.URL, 'createObjectURL').and.returnValue('blob:relatorio');
+    spyOn(window.URL, 'revokeObjectURL');
+
+    baixarBlob(response, 'fallback.pdf');
+
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(anchor.download).toBe('relatorio.pdf');
+    expect(anchor.click).toHaveBeenCalled();
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:relatorio');
+  });
+});

--- a/src/app/shared/utils/file-download.ts
+++ b/src/app/shared/utils/file-download.ts
@@ -1,0 +1,29 @@
+import { HttpResponse } from '@angular/common/http';
+
+export function extrairNomeArquivo(contentDisposition: string | null, fallback: string): string {
+  if (!contentDisposition) {
+    return fallback;
+  }
+
+  const utf8Filename = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+  if (utf8Filename?.[1]) {
+    return decodeURIComponent(utf8Filename[1].trim());
+  }
+
+  const filename = /filename="?([^";]+)"?/i.exec(contentDisposition);
+  return filename?.[1]?.trim() || fallback;
+}
+
+export function baixarBlob(response: HttpResponse<Blob>, fallbackNomeArquivo: string): void {
+  if (!response.body) {
+    return;
+  }
+
+  const nomeArquivo = extrairNomeArquivo(response.headers.get('Content-Disposition'), fallbackNomeArquivo);
+  const url = window.URL.createObjectURL(response.body);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = nomeArquivo;
+  anchor.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/src/app/shared/utils/file-download.ts
+++ b/src/app/shared/utils/file-download.ts
@@ -5,9 +5,13 @@ export function extrairNomeArquivo(contentDisposition: string | null, fallback: 
     return fallback;
   }
 
-  const utf8Filename = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+  const utf8Filename = /filename\*=UTF-8'[^']*'([^;]+)/i.exec(contentDisposition);
   if (utf8Filename?.[1]) {
-    return decodeURIComponent(utf8Filename[1].trim());
+    try {
+      return decodeURIComponent(utf8Filename[1].trim());
+    } catch {
+      return fallback;
+    }
   }
 
   const filename = /filename="?([^";]+)"?/i.exec(contentDisposition);


### PR DESCRIPTION
## Summary
- adiciona exportação PDF e Excel/XLSX no relatório de pagamento do profissional usando os endpoints da API issue FabioCarlesso/carlessopilatesapi#33
- trata resposta binária como Blob, preserva o nome do arquivo via Content-Disposition e bloqueia cliques durante a geração
- atualiza o contrato do relatório para o JSON estruturado da API e inclui resumo por pagamento na tela
- adiciona testes unitários para service, componente e utilitário de download
- atualiza README e documentação

## Testes
- npm run build
- npx ng test --watch=false --browsers=ChromeHeadless

Closes #38