### PR TITLE
fix(plano-form): subscription cleanup no ngOnDestroy #22

### DIFF
--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -637,6 +637,7 @@ Comando: `npm test`
 | `app/pages/profissionais/profissional-list/profissional-list.component.spec.ts` | Carregamento, inativação, estados de erro e janela limitada de páginas visíveis |
 | `app/pages/pacientes/paciente-form/paciente-form.component.spec.ts` | Modo criação e edição, validações, navegação, erros |
 | `app/pages/pacientes/paciente-detail/paciente-detail.component.spec.ts` | Carregamento, inativação, estados de erro |
+| `app/pages/planos/plano-form/plano-form.component.spec.ts` | Criação de plano, validação de frequência e dias, `ngOnDestroy`, reatividade do `valueChanges` |
 
 ### Estratégia de mocking
 
@@ -662,7 +663,7 @@ Comando: `npm test`
 - Design responsivo
 - Ativação e inativação de pacientes via PATCH
 - E-mail mutável na edição (somente CPF é imutável)
-- Módulo Planos: listagem, criação com seleção de dias, validação de frequência e reutilização dos labels exportados pelo model
+- Módulo Planos: listagem, criação com seleção de dias, validação de frequência, reutilização dos labels exportados pelo model e cleanup de subscriptions via `ngOnDestroy`
 - Módulo Pagamentos: listagem, criação e confirmação de pagamento (PAGO)
 - Módulo Aulas: listagem e confirmação de presença com vínculo do profissional responsável
 - Módulo Relatórios: pagamento de profissional por período e emissão de NFSEs por competência

--- a/src/app/pages/auth/login/login.component.spec.ts
+++ b/src/app/pages/auth/login/login.component.spec.ts
@@ -42,7 +42,7 @@ describe('LoginComponent', () => {
     expect(btn.disabled).toBeTrue();
   });
 
-  it('should navigate to /pacientes on successful login', () => {
+  it('should navigate to / on successful login', () => {
     authServiceSpy.login.and.returnValue(of({ accessToken: 'token' }));
     const spy = spyOn(router, 'navigate');
 
@@ -52,7 +52,7 @@ describe('LoginComponent', () => {
     comp.entrar();
 
     expect(authServiceSpy.login).toHaveBeenCalledWith({ email: 'admin@carlessopilates.com', password: 'senha1234' });
-    expect(spy).toHaveBeenCalledWith(['/pacientes']);
+    expect(spy).toHaveBeenCalledWith(['/']);
   });
 
   it('should show 401 error message on invalid credentials', () => {

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -133,4 +133,19 @@ describe('PlanoFormComponent', () => {
     expect(invalidComponent.erro).toBe('Identificador inválido.');
     expect(invalidServiceSpy.criar).not.toHaveBeenCalled();
   });
+
+  it('should unsubscribe on destroy', () => {
+    const sub = (component as any).subscriptions;
+    spyOn(sub, 'unsubscribe');
+    component.ngOnDestroy();
+    expect(sub.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('should revalidate diasSemana when frequenciaSemanal changes', () => {
+    component.form.patchValue({ frequenciaSemanal: 'UMA_VEZ', diasSemana: ['MONDAY', 'WEDNESDAY'] });
+    expect(component.form.get('diasSemana')?.hasError('diasInvalidos')).toBeTrue();
+
+    component.form.get('frequenciaSemanal')?.setValue('DUAS_VEZES');
+    expect(component.form.get('diasSemana')?.hasError('diasInvalidos')).toBeFalse();
+  });
 });

--- a/src/app/pages/planos/plano-form/plano-form.component.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { PlanoService } from '../../../core/services/plano.service';
 import {
   DiaSemana,
@@ -30,11 +31,12 @@ function diasSemanaValidator(control: AbstractControl): ValidationErrors | null 
   templateUrl: './plano-form.component.html',
   styleUrl: './plano-form.component.scss'
 })
-export class PlanoFormComponent implements OnInit {
+export class PlanoFormComponent implements OnInit, OnDestroy {
   form!: FormGroup;
   pacienteId: number | null = null;
   salvando = false;
   erro: string | null = null;
+  private subscriptions = new Subscription();
 
   readonly tipos: TipoPagamento[] = ['MENSAL', 'TRIMESTRAL', 'ANUAL'];
   readonly frequencias: FrequenciaSemanal[] = ['UMA_VEZ', 'DUAS_VEZES', 'TRES_VEZES'];
@@ -54,9 +56,11 @@ export class PlanoFormComponent implements OnInit {
       dataInicio: ['', Validators.required],
       diasSemana: [[], [Validators.required, diasSemanaValidator]]
     });
-    this.form.get('frequenciaSemanal')?.valueChanges.subscribe(() => {
-      this.form.get('diasSemana')?.updateValueAndValidity();
-    });
+    this.subscriptions.add(
+      this.form.get('frequenciaSemanal')?.valueChanges.subscribe(() => {
+        this.form.get('diasSemana')?.updateValueAndValidity();
+      })
+    );
     if (this.pacienteId === null) {
       this.erro = 'Identificador inválido.';
     }
@@ -79,6 +83,10 @@ export class PlanoFormComponent implements OnInit {
 
   campo(nome: string) {
     return this.form.get(nome);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   salvar(): void {


### PR DESCRIPTION
## Summary

- Implementa `OnDestroy` em `PlanoFormComponent` com `Subscription` composta para desinscrever o `valueChanges` de `frequenciaSemanal` ao destruir o componente, eliminando o memory leak
- Adiciona testes para verificar: chamada ao `unsubscribe` no `ngOnDestroy` e revalidação de `diasSemana` ao mudar `frequenciaSemanal`
- Corrige teste stale em `LoginComponent` que esperava navegação para `/pacientes` mas o componente já navega para `/` (dashboard) desde o PR #49

## Test plan

- [x] `npm test` — 268 testes passando, 0 falhas
- [x] `ngOnDestroy` chama `subscriptions.unsubscribe()`
- [x] `valueChanges` de `frequenciaSemanal` dispara revalidação de `diasSemana`
- [x] Comportamento de formulário, validação e navegação inalterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)