### PR TITLE
Corrige layout das ações na listagem de pacientes

### DIFF
--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.html
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.html
@@ -59,37 +59,41 @@
     </label>
   </div>
 
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Nome</th>
-        <th>E-mail</th>
-        <th>CPF</th>
-        <th>Telefone</th>
-        <th>Status</th>
-        <th>Ações</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let p of pacientes">
-        <td>{{ p.nome }}</td>
-        <td>{{ p.email }}</td>
-        <td>{{ p.cpf }}</td>
-        <td>{{ p.telefone || '-' }}</td>
-        <td>
-          <span class="status-badge" [class.inactive]="!p.ativo">
-            {{ p.ativo ? 'Ativo' : 'Inativo' }}
-          </span>
-        </td>
-        <td class="acoes">
-          <a [routerLink]="['/pacientes', p.id]" class="btn btn-sm btn-outline">Ver</a>
-          <a [routerLink]="['/pacientes', p.id, 'editar']" class="btn btn-sm btn-secondary">Editar</a>
-          <button *ngIf="p.ativo" class="btn btn-sm btn-danger" (click)="confirmarInativar(p.id)">Inativar</button>
-          <button *ngIf="!p.ativo" class="btn btn-sm btn-primary" (click)="confirmarAtivar(p.id)">Ativar</button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="table-wrap paciente-table-wrap">
+    <table class="table paciente-table">
+      <thead>
+        <tr>
+          <th>Nome</th>
+          <th>E-mail</th>
+          <th>CPF</th>
+          <th>Telefone</th>
+          <th>Status</th>
+          <th class="acoes-header">Ações</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of pacientes">
+          <td>{{ p.nome }}</td>
+          <td>{{ p.email }}</td>
+          <td>{{ p.cpf }}</td>
+          <td>{{ p.telefone || '-' }}</td>
+          <td>
+            <span class="status-badge" [class.inactive]="!p.ativo">
+              {{ p.ativo ? 'Ativo' : 'Inativo' }}
+            </span>
+          </td>
+          <td class="acoes-cell">
+            <div class="acoes" aria-label="Ações do paciente">
+              <a [routerLink]="['/pacientes', p.id]" class="btn btn-sm btn-outline">Ver</a>
+              <a [routerLink]="['/pacientes', p.id, 'editar']" class="btn btn-sm btn-secondary">Editar</a>
+              <button *ngIf="p.ativo" class="btn btn-sm btn-danger" (click)="confirmarInativar(p.id)">Inativar</button>
+              <button *ngIf="!p.ativo" class="btn btn-sm btn-primary" (click)="confirmarAtivar(p.id)">Ativar</button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
   <div class="pagination" *ngIf="totalPages > 1">
     <button type="button" [disabled]="!canGoPrevious()" (click)="paginaAnterior()">Anterior</button>

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
@@ -53,6 +53,7 @@
 
 .table {
   width: 100%;
+  min-width: 820px;
   border-collapse: collapse;
   background: var(--bg-elev);
   border-radius: var(--r-lg);
@@ -67,12 +68,32 @@
     font-weight: 600;
   }
 
-  td { padding: .75rem 1rem; border-bottom: 1px solid var(--border-subtle); }
+  td {
+    padding: .75rem 1rem;
+    border-bottom: 1px solid var(--border-subtle);
+    overflow-wrap: anywhere;
+  }
+
   tr:last-child td { border-bottom: none; }
   tr:hover td { background: var(--bg-sunken); }
 }
 
-.acoes { display: flex; gap: .5rem; }
+.acoes-header,
+.acoes-cell {
+  width: 224px;
+  min-width: 224px;
+}
+
+.acoes-cell {
+  display: table-cell;
+}
+
+.acoes {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  flex-wrap: wrap;
+}
 
 .status-badge {
   display: inline-flex;

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts
@@ -421,4 +421,15 @@ describe('PacienteListComponent', () => {
     expect(select).withContext('page size select must be present').toBeTruthy();
     expect(select.value).toBe('20');
   });
+
+  it('should render patient actions inside a wrapped actions group', () => {
+    fixture.detectChanges();
+
+    const actionsCell = fixture.nativeElement.querySelector('td.acoes-cell') as HTMLTableCellElement;
+    const actionsGroup = actionsCell?.querySelector('.acoes[aria-label="Ações do paciente"]');
+
+    expect(actionsCell).withContext('actions must stay in a table cell').toBeTruthy();
+    expect(actionsGroup).withContext('buttons must be grouped for flexible wrapping').toBeTruthy();
+    expect(actionsGroup?.querySelectorAll('.btn').length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Resumo
- Ajusta a tabela de pacientes para usar um contêiner responsivo horizontal.
- Mantém a célula da coluna Ações como célula de tabela e agrupa os botões em um wrapper flexível com espaçamento e quebra de linha.
- Define largura mínima para a coluna de ações e permite quebra segura em conteúdos longos nas demais células.
- Adiciona teste unitário para garantir a estrutura renderizada da coluna de ações.

## Motivo
Os botões `Ver`, `Editar` e `Inativar`/`Ativar` podiam ficar sobrepostos na listagem de pacientes em linhas com maior altura ou resoluções menores. O ajuste organiza os botões sem alterar o comportamento funcional existente.

## Testes executados
- `npx ng test --watch=false --browsers=ChromeHeadless --include='src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts'`
- `npx ng test --watch=false --browsers=ChromeHeadless`
- `npm run build`

## Arquivos principais alterados
- `src/app/pages/pacientes/paciente-list/paciente-list.component.html`
- `src/app/pages/pacientes/paciente-list/paciente-list.component.scss`
- `src/app/pages/pacientes/paciente-list/paciente-list.component.spec.ts`

Closes #85