### PR TITLE
docs: adiciona documentacao visual em HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Interface web para gestão administrativa de um estúdio de pilates, desenvolvid
 A aplicação oferece dashboard inicial de indicadores, CRUDs administrativos para pacientes e profissionais, fluxos de planos, pagamentos e aulas, além de relatórios administrativos. Consome uma API REST (Spring Boot) via proxy do Angular CLI.
 
 **Documentação detalhada:** [`docs/documentacao.md`](docs/documentacao.md)  
+**Documentação visual em HTML:** [`docs/documentacao.html`](docs/documentacao.html)
+
 **Contexto e decisões técnicas:** [`docs/context.md`](docs/context.md)
 
 ---

--- a/docs/documentacao.html
+++ b/docs/documentacao.html
@@ -1,0 +1,811 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Documentacao Visual | Carlesso Pilates Frontend</title>
+  <style>
+    :root {
+      --bg: #f0ede8;
+      --paper: #faf8f5;
+      --elev: #ffffff;
+      --ink: #141f2d;
+      --muted: #455157;
+      --soft: #8a96a0;
+      --brand: #374f6c;
+      --brand-2: #708da3;
+      --line: rgba(20, 31, 45, 0.14);
+      --line-strong: rgba(20, 31, 45, 0.28);
+      --success: #5a7a5e;
+      --success-bg: #e6ede4;
+      --warning: #b08842;
+      --warning-bg: #f3ead8;
+      --danger: #8c3a3a;
+      --danger-bg: #f0dcdc;
+      --info-bg: #dde5ed;
+      --shadow: 0 8px 32px rgba(20, 31, 45, 0.10), 0 2px 8px rgba(20, 31, 45, 0.06);
+      --radius: 8px;
+      color-scheme: light;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: Montserrat, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.55;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page {
+      min-height: 100vh;
+    }
+
+    .hero {
+      background:
+        linear-gradient(120deg, rgba(20, 31, 45, 0.90), rgba(55, 79, 108, 0.82)),
+        radial-gradient(circle at 80% 20%, rgba(168, 188, 202, 0.38), transparent 28%),
+        var(--brand);
+      color: #f6f4f0;
+      padding: 56px 24px 36px;
+    }
+
+    .hero-inner,
+    .content {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+
+    .eyebrow {
+      margin: 0 0 14px;
+      color: #c3d0d9;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    h3 {
+      margin: 0;
+      line-height: 1.12;
+    }
+
+    h1 {
+      max-width: 820px;
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: clamp(38px, 6vw, 72px);
+      font-weight: 400;
+    }
+
+    h2 {
+      margin-bottom: 18px;
+      font-size: clamp(26px, 3vw, 38px);
+    }
+
+    h3 {
+      margin-bottom: 8px;
+      font-size: 18px;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    .hero-copy {
+      max-width: 760px;
+      margin-top: 18px;
+      color: #ebe8e2;
+      font-size: 18px;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 34px;
+    }
+
+    .metric {
+      min-height: 116px;
+      padding: 18px;
+      border: 1px solid rgba(240, 237, 232, 0.22);
+      border-radius: var(--radius);
+      background: rgba(250, 248, 245, 0.08);
+    }
+
+    .metric strong {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 28px;
+      line-height: 1;
+    }
+
+    .metric span {
+      color: #d8d3cb;
+      font-size: 13px;
+    }
+
+    .content {
+      padding: 32px 0 64px;
+    }
+
+    .nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 28px;
+      padding: 12px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: rgba(250, 248, 245, 0.92);
+      backdrop-filter: blur(10px);
+      box-shadow: 0 1px 8px rgba(20, 31, 45, 0.06);
+    }
+
+    .nav a {
+      min-height: 34px;
+      padding: 8px 12px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--elev);
+      color: var(--brand);
+      font-size: 13px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    section {
+      margin-top: 46px;
+    }
+
+    .section-lead {
+      max-width: 820px;
+      margin-bottom: 20px;
+      color: var(--muted);
+      font-size: 16px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .grid.two {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .grid.three {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .card {
+      padding: 20px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--paper);
+      box-shadow: 0 1px 2px rgba(20, 31, 45, 0.04);
+    }
+
+    .card.compact {
+      padding: 16px;
+    }
+
+    .card p,
+    .card li {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .tag-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 5px 10px;
+      border-radius: 999px;
+      background: var(--info-bg);
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .tag.admin {
+      background: var(--warning-bg);
+      color: #6e511e;
+    }
+
+    .tag.ok {
+      background: var(--success-bg);
+      color: var(--success);
+    }
+
+    .tag.risk {
+      background: var(--danger-bg);
+      color: var(--danger);
+    }
+
+    .architecture {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 14px;
+      align-items: stretch;
+    }
+
+    .layer {
+      position: relative;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--elev);
+    }
+
+    .layer::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: -14px;
+      width: 14px;
+      height: 1px;
+      background: var(--line-strong);
+    }
+
+    .layer:last-child::after {
+      display: none;
+    }
+
+    .layer small {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--soft);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .flow {
+      display: grid;
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .flow li {
+      display: grid;
+      grid-template-columns: 38px 1fr;
+      gap: 12px;
+      align-items: start;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--elev);
+    }
+
+    .step {
+      display: grid;
+      width: 32px;
+      height: 32px;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--brand);
+      color: #fff;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .module-card {
+      border-top: 4px solid var(--brand-2);
+    }
+
+    .module-card strong {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 16px;
+    }
+
+    .module-card ul,
+    .checklist {
+      margin: 12px 0 0;
+      padding-left: 18px;
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--paper);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 760px;
+    }
+
+    th,
+    td {
+      padding: 13px 14px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      background: #f6f4f0;
+      color: var(--brand);
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    td {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    code {
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: #ebe8e2;
+      color: var(--ink);
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 0.92em;
+    }
+
+    .terminal {
+      margin-top: 14px;
+      padding: 16px;
+      overflow-x: auto;
+      border-radius: var(--radius);
+      background: #141f2d;
+      color: #f6f4f0;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+      line-height: 1.7;
+    }
+
+    .callout {
+      padding: 18px;
+      border-left: 4px solid var(--brand);
+      border-radius: 0 var(--radius) var(--radius) 0;
+      background: var(--info-bg);
+    }
+
+    .callout p {
+      color: var(--muted);
+    }
+
+    footer {
+      margin-top: 56px;
+      padding-top: 24px;
+      border-top: 1px solid var(--line);
+      color: var(--soft);
+      font-size: 13px;
+    }
+
+    @media (max-width: 860px) {
+      .hero {
+        padding-top: 40px;
+      }
+
+      .hero-grid,
+      .grid.two,
+      .grid.three,
+      .architecture {
+        grid-template-columns: 1fr;
+      }
+
+      .layer::after {
+        display: none;
+      }
+
+      .nav {
+        position: static;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="hero-inner">
+        <p class="eyebrow">Carlesso Pilates Frontend</p>
+        <h1>Documentacao visual da aplicacao Angular de gestao do estudio</h1>
+        <p class="hero-copy">
+          Este material consolida README, contexto tecnico e estrutura do codigo para explicar como o frontend
+          esta organizado, quais fluxos ja existem e como executar, testar e evoluir o projeto.
+        </p>
+
+        <div class="hero-grid" aria-label="Resumo do projeto">
+          <div class="metric">
+            <strong>Angular 19</strong>
+            <span>SPA standalone com lazy loading por rota.</span>
+          </div>
+          <div class="metric">
+            <strong>REST</strong>
+            <span>Integracao por HttpClient e proxy local em /api.</span>
+          </div>
+          <div class="metric">
+            <strong>JWT</strong>
+            <span>Login, guards, interceptor e controle por perfil.</span>
+          </div>
+          <div class="metric">
+            <strong>Karma</strong>
+            <span>Testes unitarios com Jasmine para services e paginas.</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="content">
+      <nav class="nav" aria-label="Navegacao da documentacao">
+        <a href="#visao-geral">Visao geral</a>
+        <a href="#arquitetura">Arquitetura</a>
+        <a href="#modulos">Modulos</a>
+        <a href="#fluxos">Fluxos</a>
+        <a href="#seguranca">Seguranca</a>
+        <a href="#execucao">Execucao</a>
+        <a href="#testes">Testes</a>
+        <a href="#convencoes">Convencoes</a>
+      </nav>
+
+      <section id="visao-geral">
+        <h2>Visao Geral</h2>
+        <p class="section-lead">
+          O Carlesso Pilates Frontend e a interface administrativa do estudio. A aplicacao centraliza pacientes,
+          prontuario, profissionais, planos, pagamentos, aulas, relatorios e usuarios administrativos.
+        </p>
+
+        <div class="grid three">
+          <article class="card">
+            <h3>Objetivo do produto</h3>
+            <p>
+              Apoiar a operacao do estudio com cadastros, acompanhamento clinico, controle financeiro basico,
+              confirmacao de aulas e relatorios para tomada de decisao.
+            </p>
+          </article>
+
+          <article class="card">
+            <h3>Publico de uso</h3>
+            <p>
+              Usuarios autenticados do estudio. Fluxos sensiveis como profissionais, relatorios e administracao
+              sao restritos ao perfil <code>ADMIN</code>.
+            </p>
+          </article>
+
+          <article class="card">
+            <h3>Estado atual</h3>
+            <p>
+              MVP funcional com dashboard, prontuario do paciente, autenticacao JWT, autorizacao por perfil,
+              relatorios exportaveis e CRUD administrativo de usuarios.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="arquitetura">
+        <h2>Arquitetura</h2>
+        <p class="section-lead">
+          A arquitetura segue a organizacao padrao de uma SPA Angular moderna: componentes standalone carregados
+          sob demanda, services tipados para integracao REST e uma camada global de seguranca HTTP.
+        </p>
+
+        <div class="architecture" aria-label="Diagrama de arquitetura">
+          <div class="layer">
+            <small>Apresentacao</small>
+            <h3>Pages e Shared</h3>
+            <p>Componentes standalone, formularios reativos, tabelas, dialogos e estados de carregamento.</p>
+            <div class="tag-row">
+              <span class="tag">Reactive Forms</span>
+              <span class="tag">Lazy routes</span>
+            </div>
+          </div>
+
+          <div class="layer">
+            <small>Dominio frontend</small>
+            <h3>Core</h3>
+            <p>Models, services, guards, interceptor, utilitarios de rota e helpers de download.</p>
+            <div class="tag-row">
+              <span class="tag">DTOs</span>
+              <span class="tag">HttpClient</span>
+              <span class="tag">Auth</span>
+            </div>
+          </div>
+
+          <div class="layer">
+            <small>Infraestrutura</small>
+            <h3>API e Nginx</h3>
+            <p>Chamadas relativas <code>/api/*</code> sao encaminhadas ao backend Spring Boot em desenvolvimento ou Docker.</p>
+            <div class="tag-row">
+              <span class="tag">Angular proxy</span>
+              <span class="tag">Docker</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid two" style="margin-top: 16px;">
+          <article class="card">
+            <h3>Estrutura principal</h3>
+            <ul class="checklist">
+              <li><code>src/app/core/models</code>: contratos e DTOs usados pela UI.</li>
+              <li><code>src/app/core/services</code>: integracao com endpoints REST.</li>
+              <li><code>src/app/core/guards</code>: protecao de autenticacao e perfil.</li>
+              <li><code>src/app/pages</code>: telas por dominio funcional.</li>
+              <li><code>src/app/shared</code>: componentes e utilitarios reutilizaveis.</li>
+              <li><code>src/styles/_tokens.scss</code>: tokens do Design System Carlesso.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3>Padroes tecnicos</h3>
+            <ul class="checklist">
+              <li>Componentes standalone, sem NgModules.</li>
+              <li>Imports individuais de diretivas e pipes do Angular.</li>
+              <li>Metodos e textos de dominio em portugues.</li>
+              <li>Validacao defensiva de parametros numericos de rota.</li>
+              <li>Estados explicitos de loading, erro, vazio e salvamento.</li>
+              <li>URLs relativas para preservar portabilidade entre dev e Docker.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="modulos">
+        <h2>Modulos Implementados</h2>
+        <p class="section-lead">
+          Os modulos foram organizados por area de negocio, com rotas protegidas por autenticacao e restricoes
+          administrativas onde necessario.
+        </p>
+
+        <div class="grid three">
+          <article class="card module-card">
+            <strong>Dashboard</strong>
+            <p>Resumo consolidado de pacientes, profissionais, pagamentos e aulas do mes atual.</p>
+            <div class="tag-row"><span class="tag ok">Rota /</span></div>
+          </article>
+
+          <article class="card module-card">
+            <strong>Pacientes e prontuario</strong>
+            <p>CRUD, filtros, paginacao, anamnese, avaliacao fisioterapeutica, planos de tratamento, sessoes, evolucao e reavaliacoes.</p>
+            <div class="tag-row"><span class="tag ok">Autenticado</span></div>
+          </article>
+
+          <article class="card module-card">
+            <strong>Profissionais</strong>
+            <p>CRUD completo, ativacao/inativacao, paginacao server-side e atualizacao por <code>PUT /profissionais/{id}</code>.</p>
+            <div class="tag-row"><span class="tag admin">ADMIN</span></div>
+          </article>
+
+          <article class="card module-card">
+            <strong>Planos, pagamentos e aulas</strong>
+            <p>Planos com frequencia semanal, pagamentos confirmaveis e aulas com vinculo do profissional responsavel.</p>
+            <div class="tag-row"><span class="tag ok">Operacional</span></div>
+          </article>
+
+          <article class="card module-card">
+            <strong>Relatorios</strong>
+            <p>Pagamento de profissional por periodo e emissao de NFSE por competencia, com exportacoes PDF, XLSX e CSV.</p>
+            <div class="tag-row"><span class="tag admin">ADMIN</span></div>
+          </article>
+
+          <article class="card module-card">
+            <strong>Administracao</strong>
+            <p>Hub administrativo e gestao de usuarios com criar, editar, inativar, reativar e excluir com confirmacao.</p>
+            <div class="tag-row"><span class="tag admin">ADMIN</span></div>
+          </article>
+        </div>
+      </section>
+
+      <section id="fluxos">
+        <h2>Fluxos Principais</h2>
+        <p class="section-lead">
+          Os fluxos abaixo explicam como a aplicacao se comporta nos caminhos mais relevantes de uso e integracao.
+        </p>
+
+        <div class="grid two">
+          <article class="card">
+            <h3>Autenticacao e requisicoes</h3>
+            <ol class="flow">
+              <li><span class="step">1</span><p>Usuario envia credenciais em <code>POST /api/auth/login</code>.</p></li>
+              <li><span class="step">2</span><p><code>AuthService</code> armazena <code>accessToken</code> e <code>currentUser</code> no <code>localStorage</code>.</p></li>
+              <li><span class="step">3</span><p><code>authInterceptor</code> adiciona <code>Authorization: Bearer</code> nas requisicoes protegidas.</p></li>
+              <li><span class="step">4</span><p>Resposta <code>401</code> so derruba a sessao quando indica token invalido ou expirado.</p></li>
+            </ol>
+          </article>
+
+          <article class="card">
+            <h3>Prontuario do paciente</h3>
+            <ol class="flow">
+              <li><span class="step">1</span><p>Rotas recebem <code>pacienteId</code> e validam com utilitario compartilhado.</p></li>
+              <li><span class="step">2</span><p>Componentes carregam a identificacao do paciente antes da tela especifica.</p></li>
+              <li><span class="step">3</span><p>Services acessam endpoints dedicados de anamnese, avaliacao, sessoes, evolucoes, planos e reavaliacoes.</p></li>
+              <li><span class="step">4</span><p>Fluxos de alteracao usam confirmacao quando envolvem cancelar, suspender, encerrar ou excluir.</p></li>
+            </ol>
+          </article>
+        </div>
+      </section>
+
+      <section id="seguranca">
+        <h2>Seguranca e Controle de Acesso</h2>
+        <p class="section-lead">
+          A seguranca no frontend combina autenticacao JWT, guards de rota, exibicao condicional de navegacao
+          e tratamento criterioso de respostas de erro.
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Elemento</th>
+                <th>Arquivo</th>
+                <th>Responsabilidade</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>authGuard</code></td>
+                <td><code>src/app/core/guards/auth.guard.ts</code></td>
+                <td>Bloqueia rotas quando nao ha token e redireciona para <code>/login</code>.</td>
+              </tr>
+              <tr>
+                <td><code>roleGuard</code></td>
+                <td><code>src/app/core/guards/role.guard.ts</code></td>
+                <td>Permite rotas por perfil e envia usuarios sem permissao para <code>/403</code>.</td>
+              </tr>
+              <tr>
+                <td><code>authInterceptor</code></td>
+                <td><code>src/app/core/interceptors/auth.interceptor.ts</code></td>
+                <td>Inclui bearer token e executa logout apenas quando a API sinaliza token invalido ou expirado.</td>
+              </tr>
+              <tr>
+                <td><code>AuthService</code></td>
+                <td><code>src/app/core/services/auth.service.ts</code></td>
+                <td>Centraliza token, usuario logado, role atual, helpers de permissao e limpeza de sessao.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="execucao">
+        <h2>Execucao Local e Docker</h2>
+        <p class="section-lead">
+          O frontend usa URL relativa <code>/api</code>. Em desenvolvimento, o Angular CLI encaminha para
+          <code>http://localhost:8080</code>; em container, o Nginx usa <code>BACKEND_URL</code>.
+        </p>
+
+        <div class="grid two">
+          <article class="card">
+            <h3>Desenvolvimento</h3>
+            <p>Instale dependencias e suba o servidor do Angular CLI com proxy configurado.</p>
+            <pre class="terminal">npm install
+npm start</pre>
+            <p>A aplicacao fica disponivel em <code>http://localhost:4200</code>.</p>
+          </article>
+
+          <article class="card">
+            <h3>Container</h3>
+            <p>A imagem faz build Angular em multi-stage e serve os arquivos estaticos com Nginx.</p>
+            <pre class="terminal">docker compose up --build
+
+BACKEND_URL=http://api:8080 docker compose up --build</pre>
+          </article>
+        </div>
+      </section>
+
+      <section id="testes">
+        <h2>Testes e Qualidade</h2>
+        <p class="section-lead">
+          A suite usa Karma e Jasmine. A cobertura existente contempla rotas, app component, guards, interceptor,
+          services e componentes de pagina.
+        </p>
+
+        <div class="grid two">
+          <article class="card">
+            <h3>Comando principal</h3>
+            <pre class="terminal">npm test</pre>
+            <p>Use para validar regressao de comportamento em componentes, services e guards.</p>
+          </article>
+
+          <article class="card">
+            <h3>Quando ampliar testes</h3>
+            <ul class="checklist">
+              <li>Alteracoes em rotas e precedencia de parametros.</li>
+              <li>Mudancas em services ou contratos REST.</li>
+              <li>Fluxos com permissao, token, logout ou perfil.</li>
+              <li>Componentes compartilhados e validacoes de formulario.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="convencoes">
+        <h2>Convencoes de Evolucao</h2>
+        <p class="section-lead">
+          Ao evoluir o projeto, mantenha a linguagem, os padroes de arquivo e a separacao de responsabilidades
+          ja adotados no codigo.
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Assunto</th>
+                <th>Padrao atual</th>
+                <th>Exemplo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Componentes</td>
+                <td>Standalone, PascalCase com sufixo <code>Component</code></td>
+                <td><code>PacienteFormComponent</code></td>
+              </tr>
+              <tr>
+                <td>Arquivos</td>
+                <td>Kebab-case por feature</td>
+                <td><code>paciente-form.component.ts</code></td>
+              </tr>
+              <tr>
+                <td>Services</td>
+                <td><code>providedIn: 'root'</code>, metodos em portugues e URLs relativas</td>
+                <td><code>listar()</code>, <code>buscar()</code>, <code>inativar()</code></td>
+              </tr>
+              <tr>
+                <td>Estilos</td>
+                <td>Preferir tokens semanticos a cores soltas</td>
+                <td><code>var(--primary)</code>, <code>var(--border-default)</code></td>
+              </tr>
+              <tr>
+                <td>API</td>
+                <td>DTOs tipados em <code>core/models</code> e chamadas em <code>core/services</code></td>
+                <td><code>Page&lt;PacienteResponseDTO&gt;</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout" style="margin-top: 18px;">
+          <h3>Nota de manutencao</h3>
+          <p>
+            Esta documentacao HTML e um complemento visual. A documentacao fonte continua em
+            <code>README.md</code>, <code>docs/context.md</code> e <code>docs/documentacao.md</code>.
+            Quando a arquitetura, setup ou contratos mudarem, atualize esses arquivos em conjunto.
+          </p>
+        </div>
+      </section>
+
+      <footer>
+        <p>Gerado para o projeto Carlesso Pilates Frontend. Ultima revisao documental: Maio de 2026.</p>
+      </footer>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Resumo da alteracao
- Cria `docs/documentacao.html` com uma documentacao visual e explicativa do projeto.
- Organiza conteudo de visao geral, arquitetura, modulos, fluxos, seguranca, execucao, testes e convencoes.
- Atualiza o README com link para a nova documentacao HTML.

## Motivo da mudanca
A atividade solicita avaliar as documentacoes existentes do projeto e criar um arquivo de documentacao em formato HTML na pasta `docs`, tornando as informacoes do frontend mais visuais e acessiveis.

## Testes executados
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` (542 testes com sucesso)
- `git diff --check`

## Arquivos principais alterados
- `docs/documentacao.html`
- `README.md`

## Referencia da issue
- Issue nao informada na solicitacao.