### PR TITLE
refactor: adicionar tipo de retorno explícito no método campo() dos formulários

### DIFF
--- a/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
+++ b/src/app/pages/pacientes/paciente-form/paciente-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PacienteService } from '../../../core/services/paciente.service';
 import { parseRouteNumberParam } from '../../../shared/utils/route-param';
@@ -101,7 +101,7 @@ export class PacienteFormComponent implements OnInit {
     });
   }
 
-  campo(nome: string) {
+  campo(nome: string): AbstractControl | null {
     return this.form.get(nome);
   }
 }

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.spec.ts
@@ -73,6 +73,10 @@ describe('PagamentoFormComponent', () => {
     expect(component.form.contains('periodoFim')).toBeFalse();
   });
 
+  it('campo() should return the matching AbstractControl', () => {
+    expect(component.campo('valor')).toBe(component.form.get('valor'));
+  });
+
   it('should call criar with pacienteId and navigate on valid submit', () => {
     pagamentoServiceSpy.criar.and.returnValue(of(mockPagamento));
     component.form.setValue({

--- a/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
+++ b/src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CurrencyPipe, NgFor, NgIf } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { PagamentoService } from '../../../core/services/pagamento.service';
 import { PlanoService } from '../../../core/services/plano.service';
@@ -64,7 +64,7 @@ export class PagamentoFormComponent implements OnInit {
     });
   }
 
-  campo(nome: string) {
+  campo(nome: string): AbstractControl | null {
     return this.form.get(nome);
   }
 

--- a/src/app/pages/planos/plano-form/plano-form.component.spec.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.spec.ts
@@ -50,6 +50,10 @@ describe('PlanoFormComponent', () => {
     );
   });
 
+  it('campo() should return the matching AbstractControl', () => {
+    expect(component.campo('valor')).toBe(component.form.get('valor'));
+  });
+
   it('should expose labels exported by plano model', () => {
     expect(component.tipoLabel).toBe(TIPO_LABEL);
     expect(component.frequenciaLabel).toBe(FREQUENCIA_LABEL);

--- a/src/app/pages/planos/plano-form/plano-form.component.ts
+++ b/src/app/pages/planos/plano-form/plano-form.component.ts
@@ -81,7 +81,7 @@ export class PlanoFormComponent implements OnInit, OnDestroy {
     return f ? FREQUENCIA_DIAS[f] : 0;
   }
 
-  campo(nome: string) {
+  campo(nome: string): AbstractControl | null {
     return this.form.get(nome);
   }
 

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.spec.ts
@@ -89,6 +89,10 @@ describe('ProfissionalFormComponent', () => {
       expect(component.erro).toBe('Erro ao salvar profissional.');
       expect(component.salvando).toBeFalse();
     });
+
+    it('campo() should return the matching AbstractControl', () => {
+      expect(component.campo('nome')).toBe(component.form.get('nome'));
+    });
   });
 
   describe('in edit mode', () => {

--- a/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
+++ b/src/app/pages/profissionais/profissional-form/profissional-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators, AbstractControl } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProfissionalService } from '../../../core/services/profissional.service';
 import { TIPO_CONTRATO_LABEL, TipoContrato } from '../../../core/models/profissional';
@@ -101,7 +101,7 @@ export class ProfissionalFormComponent implements OnInit {
     });
   }
 
-  campo(nome: string) {
+  campo(nome: string): AbstractControl | null {
     return this.form.get(nome);
   }
 }


### PR DESCRIPTION
## Resumo

Anota explicitamente o tipo de retorno do método auxiliar `campo()` como `AbstractControl | null` nos componentes de formulário. Onde necessário, adiciona o import de `AbstractControl` de `@angular/forms`.

```typescript
// antes
campo(nome: string) {
  return this.form.get(nome);
}

// depois
campo(nome: string): AbstractControl | null {
  return this.form.get(nome);
}
```

## Motivo

O retorno do método era inferido implicitamente, reduzindo a clareza do contrato público e podendo mascarar erros de tipo nos templates. A anotação explícita torna o contrato evidente e melhora a segurança de tipos.

## Testes executados

- `npm run build` → bundle gerado com sucesso (sem erros de compilação).
- `ng test --watch=false --browsers=ChromeHeadless` → **623 SUCCESS** (incluindo 3 novos testes de `campo()`).

## Arquivos principais alterados

- `src/app/pages/pacientes/paciente-form/paciente-form.component.ts`
- `src/app/pages/profissionais/profissional-form/profissional-form.component.ts`
- `src/app/pages/planos/plano-form/plano-form.component.ts`
- `src/app/pages/pagamentos/pagamento-form/pagamento-form.component.ts`
- Specs correspondentes: adicionado teste `campo()` para profissional, plano e pagamento (paciente já possuía).

## Referência

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrsbfV2YZiURQthTdAr1qn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrsbfV2YZiURQthTdAr1qn)_