### PR TITLE
feat: configurar vercel.json para roteamento de API em produção (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ docker run --rm -p 4200:80 \
 
 ---
 
+## Deploy (Vercel)
+
+Em produção a aplicação é hospedada na **Vercel** (`carlessopilatesfe.vercel.app`). Como a Vercel não tem o proxy do Angular CLI nem o Nginx do Docker, o roteamento de API é feito pelo [`vercel.json`](vercel.json), que replica o comportamento do `proxy.conf.json`:
+
+- Requisições para `/api/*` são reescritas para o backend público no Railway, **removendo o prefixo `/api`** (mesmo efeito do `pathRewrite: { "^/api": "" }` do proxy de dev e do `proxy_pass ${BACKEND_URL}/` do Nginx).
+- O destino é a URL pública do Railway (`https://carlessopilatesapi-production.up.railway.app`), acessada via HTTPS na 443 — a porta interna do container (8080) é resolvida pelo próprio Railway e **não** entra na URL.
+
+> Rewrites do `vercel.json` não interpolam variáveis de ambiente, portanto a URL do backend é fixa no arquivo. Se o domínio do Railway mudar, o `vercel.json` precisa ser atualizado e é necessário um novo commit/deploy. Lembre-se de manter a URL da Vercel na variável `CORS_ALLOWED_ORIGINS` do backend.
+
+---
+
 ## Stack
 
 | Camada     | Tecnologia                    |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -431,7 +431,7 @@ Injetável em toda a aplicação (`providedIn: 'root'`).
 
 **URL base no frontend:** `/api/pacientes`
 
-Em desenvolvimento local, o Angular CLI redireciona `/api` para `http://localhost:8080` via `proxy.conf.json`. Em Docker, o Nginx redireciona `/api` para o valor de `BACKEND_URL`.
+Em desenvolvimento local, o Angular CLI redireciona `/api` para `http://localhost:8080` via `proxy.conf.json`. Em Docker, o Nginx redireciona `/api` para o valor de `BACKEND_URL`. Em produção (Vercel), o `vercel.json` reescreve `/api/*` para o backend público no Railway, removendo o prefixo `/api` — o mesmo comportamento dos ambientes anteriores.
 
 | Método            | Endpoint HTTP               | Descrição                        |
 |-------------------|-----------------------------|----------------------------------|

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://carlessopilatesapi-production.up.railway.app/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Resumo
- Adiciona `vercel.json` na raiz reescrevendo `/api/*` para o backend público no Railway, removendo o prefixo `/api` (mesmo comportamento do `proxy.conf.json` de dev e do Nginx no Docker).
- Documenta o roteamento de API em produção (Vercel) no `README.md` e em `docs/documentacao.md`.

## Motivo
Em produção (Vercel) não existe o proxy do Angular CLI nem o Nginx do Docker, então as chamadas `/api/*` falhavam. O `vercel.json` replica o proxy de dev em produção. Closes #113.

## Decisões técnicas
- **URL fixa** no `vercel.json`: rewrites da Vercel não interpolam variáveis de ambiente, então parametrizar via env var exigiria serverless/edge function — desnecessário para espelhar o proxy. Documentado que a troca de domínio exige novo commit.
- **Sem porta no destino**: o domínio público do Railway é servido via HTTPS/443; a porta interna do container (8080) é resolvida pelo próprio Railway e não entra na URL.

## Testes executados
- [x] `node -e JSON.parse(...)` — `vercel.json` é JSON válido
- [x] `npm run build` — build de produção concluído sem erros
- [x] `git diff proxy.conf.json` vazio — proxy de dev inalterado (sem regressão local)
- [ ] Smoke test em produção: login `/api/auth/login` retornar 200 após deploy na Vercel (validação manual pós-merge)
- [ ] Confirmar `CORS_ALLOWED_ORIGINS` no backend (Railway) inclui a URL da Vercel

## Arquivos principais alterados
- `vercel.json` — novo: rewrite `/api/:path*` → `https://carlessopilatesapi-production.up.railway.app/:path*`
- `README.md` — seção "Deploy (Vercel)" descrevendo o roteamento em produção
- `docs/documentacao.md` — nota sobre o roteamento de API em produção

## Referência
Issue: #113 — feat: configurar vercel.json para roteamento de API em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)