### PR TITLE
fix: elevar fonte de campos para 16px no mobile (evita zoom no iOS)

### DIFF
--- a/src/app/pages/auth/forgot-password/forgot-password.component.scss
+++ b/src/app/pages/auth/forgot-password/forgot-password.component.scss
@@ -133,3 +133,11 @@
 .btn-voltar-login {
   margin-top: 0.5rem;
 }
+
+// O Safari iOS aplica zoom automático ao focar campos com fonte menor que 16px.
+// No mobile os inputs sobem para 16px para evitar o zoom (issue #160).
+@media (max-width: 768px) {
+  .form-group input {
+    font-size: 16px;
+  }
+}

--- a/src/app/pages/auth/login/login.component.scss
+++ b/src/app/pages/auth/login/login.component.scss
@@ -127,3 +127,11 @@
     cursor: not-allowed;
   }
 }
+
+// O Safari iOS aplica zoom automático ao focar campos com fonte menor que 16px.
+// No mobile os inputs sobem para 16px para evitar o zoom (issue #160).
+@media (max-width: 768px) {
+  .form-group input {
+    font-size: 16px;
+  }
+}

--- a/src/app/pages/auth/reset-password/reset-password.component.scss
+++ b/src/app/pages/auth/reset-password/reset-password.component.scss
@@ -163,3 +163,11 @@
     text-decoration: underline;
   }
 }
+
+// O Safari iOS aplica zoom automático ao focar campos com fonte menor que 16px.
+// No mobile os inputs sobem para 16px para evitar o zoom (issue #160).
+@media (max-width: 768px) {
+  .password-field input {
+    font-size: 16px;
+  }
+}

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
@@ -36,6 +36,13 @@
     background: var(--bg-elev);
     color: var(--text-primary);
     font: inherit;
+
+    // O Safari iOS aplica zoom automático ao focar campos com fonte menor que
+    // 16px. Os filtros herdam --fs-body (14px) do body; no mobile subimos para
+    // 16px para evitar o zoom (issue #160).
+    @media (max-width: 768px) {
+      font-size: 16px;
+    }
   }
 
   input::placeholder {

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.scss
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.scss
@@ -41,6 +41,13 @@
     background: var(--bg-elev);
     color: var(--text-primary);
     font: inherit;
+
+    // O Safari iOS aplica zoom automático ao focar campos com fonte menor que
+    // 16px. Os filtros herdam --fs-body (14px) do body; no mobile subimos para
+    // 16px para evitar o zoom (issue #160).
+    @media (max-width: 768px) {
+      font-size: 16px;
+    }
   }
 
   input::placeholder {

--- a/src/app/shared/components/busca-global/busca-global.component.scss
+++ b/src/app/shared/components/busca-global/busca-global.component.scss
@@ -137,3 +137,12 @@
     width: 100%;
   }
 }
+
+// O Safari iOS aplica zoom automático ao focar campos com fonte menor que 16px.
+// O campo de busca usa --fs-body-sm (13px); no mobile sobe para 16px para
+// evitar o zoom (issue #160).
+@media (max-width: 768px) {
+  .busca-global-campo {
+    font-size: 16px;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -662,4 +662,17 @@ body.dialog-aberto {
   .container {
     margin: var(--sp-5) auto;
   }
+
+  // O Safari iOS aplica zoom automático ao focar campos cuja fonte é menor que
+  // 16px. No desktop os campos usam --fs-body (14px); no mobile subimos para
+  // 16px para evitar o zoom, sem restringir o zoom do usuário no meta viewport
+  // (issue #160). Cobre os campos globais; login e filtros têm overrides
+  // próprios nos respectivos componentes.
+  .form-control,
+  .input,
+  .select,
+  .textarea,
+  .form-control-sm {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
## Resumo
- Campos de formulário passam a renderizar com `font-size: 16px` em telas ≤ 768px (`.form-control`/`.input`/`.select`/`.textarea` e `.form-control-sm`).
- Overrides mobile também para os inputs de login, recuperação/redefinição de senha e filtros das listagens de pacientes/profissionais.
- Meta viewport permanece sem `maximum-scale`/`user-scalable=no`, preservando o zoom do usuário.

## Motivo
O Safari iOS aplica zoom automático ao focar campos com fonte menor que 16px (no projeto os campos usavam 14px/~15.2px), deslocando o layout a cada foco. Closes #160.

## Testes executados
- [x] `npm run build` — sucesso
- [x] `npm run lint` — All files pass linting
- [x] `npm run test:ci` — 771 SUCCESS
- [ ] Validação manual no Safari iOS / emulação (375px e 414px) — recomendada

## Arquivos principais alterados
- `src/styles.scss` — media query mobile com `font-size: 16px` nos campos globais
- `src/app/pages/auth/login/login.component.scss` — inputs do login a 16px no mobile
- `src/app/pages/auth/forgot-password/…scss` e `reset-password/…scss` — inputs a 16px no mobile
- `src/app/pages/pacientes/paciente-list/…scss` e `profissionais/profissional-list/…scss` — inputs de filtro a 16px no mobile

## Referência
Issue: #160 — Mobile: iOS aplica zoom automático ao focar inputs porque a fonte é menor que 16px

🤖 Generated with [Claude Code](https://claude.com/claude-code)