### PR TITLE
fix: paginação compacta em uma linha no mobile (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Componentes globais como botões, inputs, cards, badges, tabelas, paginação, a
 
 ### Responsividade
 
-O layout é pensado também para uso em tablet na recepção. A navbar colapsa num menu (botão ☰) em telas `≤1024px`, cobrindo a faixa de tablet (retrato e paisagem) em que os links e ações não caberiam na barra — o breakpoint é compartilhado com a constante `DESKTOP_MIN_WIDTH` do `AppComponent`, que fecha o menu ao voltar para o desktop. As tabelas rolam horizontalmente dentro do contêiner (`.table-responsive`/`.table-wrap`) sem gerar scroll da página, os formulários passam de múltiplas colunas para uma coluna em `≤768px`, e botões de ação de linha e paginação usam alvo de toque de `≥44px` em `≤1024px`. Tema e densidade são preservados em todas as larguras.
+O layout é pensado também para uso em tablet na recepção. A navbar colapsa num menu (botão ☰) em telas `≤1024px`, cobrindo a faixa de tablet (retrato e paisagem) em que os links e ações não caberiam na barra — o breakpoint é compartilhado com a constante `DESKTOP_MIN_WIDTH` do `AppComponent`, que fecha o menu ao voltar para o desktop. As tabelas rolam horizontalmente dentro do contêiner (`.table-responsive`/`.table-wrap`) sem gerar scroll da página, os formulários passam de múltiplas colunas para uma coluna em `≤768px`, e botões de ação de linha e paginação usam alvo de toque de `≥44px` em `≤1024px`. Em `≤768px` a paginação das listagens (pacientes, profissionais e usuários) passa a um formato compacto de uma única linha — **Anterior / Página X de N / Próxima** —, ocultando a janela de páginas numeradas (mantida no desktop `≥769px`) para evitar quebra em várias linhas no mobile. Tema e densidade são preservados em todas as larguras.
 
 ### Tema claro/escuro
 

--- a/src/app/pages/admin/usuarios/usuario-list/usuario-list.component.html
+++ b/src/app/pages/admin/usuarios/usuario-list/usuario-list.component.html
@@ -65,12 +65,30 @@
 
 <div class="pagination" *ngIf="totalPages > 1" role="navigation" aria-label="Paginação de usuários">
   <button
+    type="button"
+    class="page-nav-mobile"
+    aria-label="Página anterior"
+    [disabled]="currentPage === 0"
+    (click)="pagina(currentPage - 1)">
+    Anterior
+  </button>
+  <span class="page-status" aria-live="polite">Página {{ currentPage + 1 }} de {{ totalPages }}</span>
+  <button
     *ngFor="let p of visiblePages"
+    class="page-number"
     [class.active]="p === currentPage"
     [attr.aria-label]="'Página ' + (p + 1)"
     [attr.aria-current]="p === currentPage ? 'page' : null"
     (click)="pagina(p)">
     {{ p + 1 }}
+  </button>
+  <button
+    type="button"
+    class="page-nav-mobile"
+    aria-label="Próxima página"
+    [disabled]="currentPage === totalPages - 1"
+    (click)="pagina(currentPage + 1)">
+    Próxima
   </button>
 </div>
 

--- a/src/app/pages/admin/usuarios/usuario-list/usuario-list.component.spec.ts
+++ b/src/app/pages/admin/usuarios/usuario-list/usuario-list.component.spec.ts
@@ -389,7 +389,7 @@ describe('UsuarioListComponent', () => {
 
     fixture.detectChanges();
 
-    const buttons = fixture.nativeElement.querySelectorAll('.pagination button');
+    const buttons = fixture.nativeElement.querySelectorAll('.pagination .page-number');
     expect(buttons.length).toBe(5);
   });
 
@@ -549,7 +549,7 @@ describe('UsuarioListComponent', () => {
     component.visiblePages = component.pages();
     fixture.detectChanges();
 
-    const buttons = fixture.nativeElement.querySelectorAll('.pagination button') as NodeListOf<HTMLButtonElement>;
+    const buttons = fixture.nativeElement.querySelectorAll('.pagination .page-number') as NodeListOf<HTMLButtonElement>;
     expect(buttons[0].getAttribute('aria-label')).toBe('Página 1');
     expect(buttons[1].getAttribute('aria-current')).toBe('page');
     expect(buttons[0].getAttribute('aria-current')).toBeNull();

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.html
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.html
@@ -96,10 +96,12 @@
     </table>
   </div>
 
-  <div class="pagination" *ngIf="totalPages > 1">
+  <div class="pagination" *ngIf="totalPages > 1" role="navigation" aria-label="Paginação de pacientes">
     <button type="button" [disabled]="!canGoPrevious()" (click)="paginaAnterior()">Anterior</button>
+    <span class="page-status" aria-live="polite">Página {{ currentPage + 1 }} de {{ totalPages }}</span>
     <button
       type="button"
+      class="page-number"
       *ngFor="let p of pages()"
       [class.active]="p === currentPage"
       [attr.aria-current]="p === currentPage ? 'page' : null"

--- a/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
+++ b/src/app/pages/pacientes/paciente-list/paciente-list.component.scss
@@ -181,6 +181,17 @@
   }
 }
 
+@media (max-width: 768px) {
+  // Na paginação compacta do mobile (issue #161) mostramos apenas
+  // "Anterior / Página X de N / Próxima". O `justify-content: center` acima
+  // venceria a regra global (`.pagination { justify-content: space-between }`)
+  // por especificidade, agrupando os controles no centro; aqui garantimos que
+  // Anterior/Próxima fiquem nas extremidades, alinhando com as demais listagens.
+  .pagination {
+    justify-content: space-between;
+  }
+}
+
 @media (max-width: 640px) {
   .pagination-summary {
     align-items: flex-start;

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.html
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.html
@@ -78,9 +78,32 @@
   </table>
 </div>
 
-<div class="pagination" *ngIf="totalPages > 1">
-  <button *ngFor="let p of visiblePages" [class.active]="p === currentPage" (click)="pagina(p)">
+<div class="pagination" *ngIf="totalPages > 1" role="navigation" aria-label="Paginação de profissionais">
+  <button
+    type="button"
+    class="page-nav-mobile"
+    aria-label="Página anterior"
+    [disabled]="currentPage === 0"
+    (click)="pagina(currentPage - 1)">
+    Anterior
+  </button>
+  <span class="page-status" aria-live="polite">Página {{ currentPage + 1 }} de {{ totalPages }}</span>
+  <button
+    *ngFor="let p of visiblePages"
+    class="page-number"
+    [class.active]="p === currentPage"
+    [attr.aria-label]="'Página ' + (p + 1)"
+    [attr.aria-current]="p === currentPage ? 'page' : null"
+    (click)="pagina(p)">
     {{ p + 1 }}
+  </button>
+  <button
+    type="button"
+    class="page-nav-mobile"
+    aria-label="Próxima página"
+    [disabled]="currentPage === totalPages - 1"
+    (click)="pagina(currentPage + 1)">
+    Próxima
   </button>
 </div>
 

--- a/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
+++ b/src/app/pages/profissionais/profissional-list/profissional-list.component.spec.ts
@@ -348,7 +348,7 @@ describe('ProfissionalListComponent', () => {
     (component as unknown as { cdr: ChangeDetectorRef }).cdr.markForCheck();
     fixture.detectChanges();
 
-    const buttons = fixture.nativeElement.querySelectorAll('.pagination button');
+    const buttons = fixture.nativeElement.querySelectorAll('.pagination .page-number');
     expect(buttons.length).toBe(5);
   });
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -424,6 +424,21 @@ select.form-control,
       cursor: not-allowed;
     }
   }
+
+  // Resumo "Página X de N" e botões Anterior/Próxima usados apenas na paginação
+  // compacta do mobile (issue #161). No desktop ficam ocultos e a janela de
+  // páginas numeradas (.page-number) segue sendo exibida normalmente.
+  .page-status {
+    display: none;
+    align-items: center;
+    color: var(--text-secondary);
+    font-size: var(--fs-body);
+    font-weight: 600;
+  }
+
+  .page-nav-mobile {
+    display: none;
+  }
 }
 
 .alert {
@@ -646,6 +661,28 @@ body.dialog-aberto {
 }
 
 @media (max-width: 768px) {
+  // Paginação compacta no mobile: em telas estreitas (ex.: 375px/414px) a janela
+  // de até 7 botões quebrava em várias linhas. Aqui ocultamos os números e
+  // mostramos apenas "Anterior / Página X de N / Próxima" numa única linha, com
+  // os controles Anterior/Próxima nas extremidades (issue #161). A janela de 5
+  // páginas do desktop (≥769px) permanece inalterada.
+  .pagination {
+    flex-wrap: nowrap;
+    justify-content: space-between;
+
+    .page-number {
+      display: none;
+    }
+
+    .page-status {
+      display: inline-flex;
+    }
+
+    .page-nav-mobile {
+      display: inline-flex;
+    }
+  }
+
   .page-header {
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
## Resumo
- Em `≤768px`, oculta a janela de páginas numeradas e exibe **Anterior / Página X de N / Próxima** numa única linha nas listagens de pacientes, profissionais e usuários.
- Adiciona controles Anterior/Próxima (mobile) e resumo da página em profissionais e usuários, que antes só tinham números; mantém `aria-current` nos números.
- Preserva a janela de 5 páginas no desktop (`≥769px`) e o alvo de toque `≥44px` já existente em `≤1024px`.

## Motivo
Em 375px/414px, a paginação de pacientes (Anterior + 5 números + Próxima) quebrava em várias linhas com botões pequenos e sem ordem visual clara. Closes #161.

## Testes executados
- [x] `npm run test:ci` — 771 SUCCESS
- [x] `npm run lint` — All files pass linting
- [x] `npm run build` — Application bundle generation complete

## Arquivos principais alterados
- `src/styles.scss` — estilos base de `.page-status`/`.page-nav-mobile` e regras `@media (max-width: 768px)` para o formato compacto
- `src/app/pages/pacientes/paciente-list/paciente-list.component.html` — classe `page-number`, resumo da página e `role`/`aria-label` de navegação
- `src/app/pages/profissionais/profissional-list/profissional-list.component.html` — Anterior/Próxima mobile, resumo, `aria-current`/`aria-label`
- `src/app/pages/admin/usuarios/usuario-list/usuario-list.component.html` — Anterior/Próxima mobile e resumo
- `*.spec.ts` (profissionais/usuários) — seletores ajustados para `.pagination .page-number`
- `README.md` — nota sobre a paginação compacta no mobile

## Referência
Issue: #161 — Mobile: paginação com botões pequenos (~33px) e janela de até 7 botões que quebra em várias linhas