### PR TITLE
chore: configurar CodeGraph para indexação semântica do projeto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log
 
 # Miscellaneous
 /.angular/cache
+/.codegraph
 .sass-cache/
 /connect.lock
 /coverage

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@colbymchenry/codegraph@1.4.1", "serve", "--mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ npm install
 
 ---
 
+## CodeGraph (contexto para agentes de IA)
+
+O projeto é indexado pelo [CodeGraph](https://github.com/colbymchenry/codegraph), que mantém um grafo semântico do código (símbolos, chamadas e dependências) para que agentes de IA respondam perguntas de arquitetura em uma única consulta, em vez de explorar arquivo por arquivo.
+
+A configuração é versionada e não exige instalação global:
+
+- [`.mcp.json`](.mcp.json) — registra o servidor MCP `codegraph` (via `npx`, versão fixada) para o Claude Code do projeto.
+- [`codegraph.json`](codegraph.json) — exclui do índice o que não é código da aplicação: `assets/` (protótipos HTML/JSX do Design System), `docs/documentacao.html`, `nginx/` e `public/`. O `.gitignore` já é respeitado por padrão, então `node_modules`, `dist` e `coverage` ficam de fora automaticamente.
+- O índice é gravado em `.codegraph/` (ignorado pelo Git) e sincroniza sozinho a cada alteração de arquivo.
+
+Para gerar o índice pela primeira vez após clonar o repositório:
+
+```bash
+npx @colbymchenry/codegraph init
+```
+
+Comandos úteis fora do agente:
+
+```bash
+npx @colbymchenry/codegraph status                       # estatísticas do índice
+npx @colbymchenry/codegraph explore "fluxo de login"     # símbolos, código e call paths
+npx @colbymchenry/codegraph impact AuthService           # o que é afetado ao alterar um símbolo
+```
+
+O CodeGraph é ferramenta de apoio ao desenvolvimento: não entra no bundle, no Docker nem na CI.
+
+---
+
 ## Integração Contínua (CI)
 
 A cada `push` na `master` e a cada `pull_request`, o workflow

--- a/codegraph.json
+++ b/codegraph.json
@@ -1,0 +1,8 @@
+{
+  "exclude": [
+    "assets/",
+    "docs/documentacao.html",
+    "nginx/",
+    "public/"
+  ]
+}

--- a/docs/context.md
+++ b/docs/context.md
@@ -368,6 +368,23 @@ BACKEND_URL=http://api:8080 docker compose up --build
 
 ---
 
+## Ferramental de Desenvolvimento
+
+### CodeGraph
+
+O repositório é indexado pelo [CodeGraph](https://github.com/colbymchenry/codegraph), que constrói um grafo semântico do código (símbolos, chamadas, dependências e *blast radius*) consumido por agentes de IA via MCP. O objetivo é reduzir a exploração arquivo por arquivo em um projeto que já passa de 150 arquivos TypeScript, entregando em uma consulta os símbolos relevantes, o código-fonte e quem depende deles.
+
+Decisões de configuração:
+
+- **Servidor MCP versionado no repositório** (`.mcp.json`), e não em `~/.claude.json`, para que a configuração acompanhe o projeto e valha para toda a equipe.
+- **Execução via `npx` com versão fixada** (`@colbymchenry/codegraph@1.4.1`), evitando exigir instalação global da CLI e mantendo o comportamento reprodutível entre máquinas.
+- **Exclusões em `codegraph.json`**: `assets/` (protótipos HTML e auxiliares `.jsx` do Design System — React em um projeto Angular polui o grafo), `docs/documentacao.html`, `nginx/` e `public/`. O `.gitignore` já é respeitado nativamente, então `node_modules`, `dist`, `coverage` e `.angular/cache` não precisam ser listados.
+- **Índice em `.codegraph/`**, adicionado ao `.gitignore` — é artefato local, regenerável por `npx @colbymchenry/codegraph init` e sincronizado automaticamente a cada alteração de arquivo.
+
+A ferramenta é de apoio ao desenvolvimento e não tem qualquer efeito sobre o bundle da aplicação, a imagem Docker ou o pipeline de CI.
+
+---
+
 ## Informações do Repositório
 
 - **Repositório:** `carlessopilatesfe`


### PR DESCRIPTION
## Resumo
- Configura o [CodeGraph](https://github.com/colbymchenry/codegraph) no projeto, expondo um grafo semântico do código para agentes de IA via MCP.
- Servidor MCP versionado em `.mcp.json` e executado por `npx` com versão fixada (`@colbymchenry/codegraph@1.4.1`) — nenhuma instalação global é necessária.
- Índice enxuto via `codegraph.json`, excluindo o que não é código da aplicação.

## Motivo
O repositório já passa de 150 arquivos TypeScript, e responder perguntas de arquitetura hoje exige exploração arquivo por arquivo. O CodeGraph devolve em uma consulta os símbolos relevantes, o código-fonte e o *blast radius* (quem depende do que), reduzindo esse custo.

Decisões:
- **`.mcp.json` no repositório**, e não em `~/.claude.json`, para que a configuração acompanhe o projeto e valha para toda a equipe.
- **`npx` com versão fixada** em vez de instalação global, para reprodutibilidade entre máquinas e zero setup após o clone.
- **Exclusões**: `assets/` (protótipos HTML e auxiliares `.jsx` do Design System — React em projeto Angular polui o grafo), `docs/documentacao.html`, `nginx/` e `public/`. O `.gitignore` é respeitado nativamente, então `node_modules`, `dist` e `coverage` já ficam de fora.
- **`.codegraph/` no `.gitignore`**: artefato local, regenerável e sincronizado automaticamente.

Nada disso afeta o bundle da aplicação, a imagem Docker ou o pipeline de CI.

## Testes executados
- [x] `npx @colbymchenry/codegraph init` — índice construído: 153 arquivos, 2.058 nós, 4.612 arestas; 148 TypeScript e apenas 2 JavaScript (`eslint.config.js`, `karma.conf.js`), confirmando que os `.jsx` de `assets/` foram excluídos
- [x] `npx @colbymchenry/codegraph explore "..."` — consulta real retornou símbolos, código e blast radius corretos do `authInterceptor`
- [x] `npm run lint` — All files pass linting
- [x] `npm run test:ci` — 783/783 SUCCESS (cobertura de linhas 94,62%)
- [x] `npm run build` — Application bundle generation complete
- [ ] Validação do servidor MCP dentro do Claude Code exige reiniciar a sessão e aprovar o servidor do projeto

## Arquivos principais alterados
- `.mcp.json` — novo; registra o servidor MCP `codegraph` (stdio, via `npx`)
- `codegraph.json` — novo; exclusões do índice
- `.gitignore` — ignora `/.codegraph`
- `README.md` — nova seção "CodeGraph (contexto para agentes de IA)" com uso e comandos
- `docs/context.md` — nova seção "Ferramental de Desenvolvimento" com as decisões de configuração

## Referência
Sem issue associada — solicitação direta para configurar o CodeGraph no projeto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)