### PR TITLE
fix: alvo de toque de 44px e viewport mobile nas listagens e autenticação

### DIFF
--- a/src/app/pages/aulas/aula-list/aula-list.component.scss
+++ b/src/app/pages/aulas/aula-list/aula-list.component.scss
@@ -1,7 +1,6 @@
 .badge { padding: 2px 10px; border-radius: var(--radius); font-size: 0.85rem; font-weight: 600; }
 .badge-realizada { background: var(--c-success-bg); color: var(--c-success); }
 .badge-pendente { background: var(--bg-sunken); color: var(--text-light); }
-.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
 .empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }
 
 :host {

--- a/src/app/pages/auth/forgot-password/forgot-password.component.scss
+++ b/src/app/pages/auth/forgot-password/forgot-password.component.scss
@@ -1,24 +1,21 @@
+// Desconta as margens verticais de `main.container` para não gerar scroll
+// residual, mesmo padrão de forbidden.component.scss. `dvh` acompanha a
+// barra de URL no mobile; `vh` fica como fallback (issue #165).
 .auth-container {
-  position: relative;
   display: flex;
-  min-height: 100vh;
-  min-height: 100dvh;
+  flex-direction: column;
+  min-height: calc(100vh - (var(--gutter) * 2));
+  min-height: calc(100dvh - (var(--gutter) * 2));
   padding: 1.5rem 1rem;
   background: var(--bg-app);
 }
 
-// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
-// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
-@media (max-height: 500px) {
-  .auth-container {
-    padding-top: 4rem;
-  }
-}
-
+// O toggle fica no fluxo (e não absoluto) para nunca sobrepor o card em
+// telas baixas. O `margin: auto` do card o centraliza no espaço restante
+// e permite scroll natural quando o conteúdo não cabe (issue #165).
 .auth-theme-toggle {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
+  align-self: flex-end;
+  flex: none;
 }
 
 .auth-card {

--- a/src/app/pages/auth/forgot-password/forgot-password.component.scss
+++ b/src/app/pages/auth/forgot-password/forgot-password.component.scss
@@ -1,10 +1,18 @@
 .auth-container {
   position: relative;
   display: flex;
-  align-items: center;
-  justify-content: center;
   min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1.5rem 1rem;
   background: var(--bg-app);
+}
+
+// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
+// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
+@media (max-height: 500px) {
+  .auth-container {
+    padding-top: 4rem;
+  }
 }
 
 .auth-theme-toggle {
@@ -14,6 +22,7 @@
 }
 
 .auth-card {
+  margin: auto;
   background: var(--bg-elev);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
@@ -102,6 +111,7 @@
   border: none;
   border-radius: var(--r-md);
   padding: 0.75rem;
+  min-height: 44px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/src/app/pages/auth/login/login.component.scss
+++ b/src/app/pages/auth/login/login.component.scss
@@ -1,24 +1,21 @@
+// Desconta as margens verticais de `main.container` para não gerar scroll
+// residual, mesmo padrão de forbidden.component.scss. `dvh` acompanha a
+// barra de URL no mobile; `vh` fica como fallback (issue #165).
 .login-container {
-  position: relative;
   display: flex;
-  min-height: 100vh;
-  min-height: 100dvh;
+  flex-direction: column;
+  min-height: calc(100vh - (var(--gutter) * 2));
+  min-height: calc(100dvh - (var(--gutter) * 2));
   padding: 1.5rem 1rem;
   background: var(--bg-app);
 }
 
-// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
-// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
-@media (max-height: 500px) {
-  .login-container {
-    padding-top: 4rem;
-  }
-}
-
+// O toggle fica no fluxo (e não absoluto) para nunca sobrepor o card em
+// telas baixas. O `margin: auto` do card o centraliza no espaço restante
+// e permite scroll natural quando o conteúdo não cabe (issue #165).
 .login-theme-toggle {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
+  align-self: flex-end;
+  flex: none;
 }
 
 .login-card {

--- a/src/app/pages/auth/login/login.component.scss
+++ b/src/app/pages/auth/login/login.component.scss
@@ -1,10 +1,18 @@
 .login-container {
   position: relative;
   display: flex;
-  align-items: center;
-  justify-content: center;
   min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1.5rem 1rem;
   background: var(--bg-app);
+}
+
+// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
+// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
+@media (max-height: 500px) {
+  .login-container {
+    padding-top: 4rem;
+  }
 }
 
 .login-theme-toggle {
@@ -14,6 +22,7 @@
 }
 
 .login-card {
+  margin: auto;
   background: var(--bg-elev);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
@@ -113,6 +122,7 @@
   border: none;
   border-radius: var(--r-md);
   padding: 0.75rem;
+  min-height: 44px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/src/app/pages/auth/reset-password/reset-password.component.scss
+++ b/src/app/pages/auth/reset-password/reset-password.component.scss
@@ -1,10 +1,18 @@
 .auth-container {
   position: relative;
   display: flex;
-  align-items: center;
-  justify-content: center;
   min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1.5rem 1rem;
   background: var(--bg-app);
+}
+
+// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
+// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
+@media (max-height: 500px) {
+  .auth-container {
+    padding-top: 4rem;
+  }
 }
 
 .auth-theme-toggle {
@@ -14,6 +22,7 @@
 }
 
 .auth-card {
+  margin: auto;
   background: var(--bg-elev);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
@@ -130,6 +139,7 @@
   border: none;
   border-radius: var(--r-md);
   padding: 0.75rem;
+  min-height: 44px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/src/app/pages/auth/reset-password/reset-password.component.scss
+++ b/src/app/pages/auth/reset-password/reset-password.component.scss
@@ -1,24 +1,21 @@
+// Desconta as margens verticais de `main.container` para não gerar scroll
+// residual, mesmo padrão de forbidden.component.scss. `dvh` acompanha a
+// barra de URL no mobile; `vh` fica como fallback (issue #165).
 .auth-container {
-  position: relative;
   display: flex;
-  min-height: 100vh;
-  min-height: 100dvh;
+  flex-direction: column;
+  min-height: calc(100vh - (var(--gutter) * 2));
+  min-height: calc(100dvh - (var(--gutter) * 2));
   padding: 1.5rem 1rem;
   background: var(--bg-app);
 }
 
-// Em telas muito baixas (ex.: mobile em paisagem), reserva espaço no topo
-// para o toggle de tema não sobrepor o card ao centralizar (issue #165).
-@media (max-height: 500px) {
-  .auth-container {
-    padding-top: 4rem;
-  }
-}
-
+// O toggle fica no fluxo (e não absoluto) para nunca sobrepor o card em
+// telas baixas. O `margin: auto` do card o centraliza no espaço restante
+// e permite scroll natural quando o conteúdo não cabe (issue #165).
 .auth-theme-toggle {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
+  align-self: flex-end;
+  flex: none;
 }
 
 .auth-card {

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
@@ -2,7 +2,6 @@
 .badge-pendente { background: var(--c-warning-bg); color: var(--c-warning); }
 .badge-pago { background: var(--c-success-bg); color: var(--c-success); }
 .badge-vencido { background: var(--c-danger-bg); color: var(--c-danger); }
-.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
 .empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }
 
 // Largura mínima para o scroll horizontal ficar contido no .table-wrap

--- a/src/app/pages/planos/plano-list/plano-list.component.scss
+++ b/src/app/pages/planos/plano-list/plano-list.component.scss
@@ -6,10 +6,11 @@
 }
 .badge-ativo { background: var(--c-success-bg); color: var(--c-success); }
 .badge-inativo { background: var(--c-danger-bg); color: var(--c-danger); }
-.btn-sm { padding: 4px 10px; font-size: 0.85rem; }
 
 // Largura mínima para o scroll horizontal ficar contido no .table-wrap
 // em vez de estourar a página no celular.
 .table { min-width: 900px; }
-.acoes-col { display: flex; gap: 6px; white-space: nowrap; }
+// Gap alinhado ao --sp-2 (8px) usado nos demais contêineres de ação de linha,
+// espaçamento mínimo recomendado entre alvos de toque vizinhos (issue #162).
+.acoes-col { display: flex; gap: var(--sp-2); white-space: nowrap; }
 .empty-state { color: var(--text-light); margin-top: 2rem; text-align: center; }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -643,14 +643,21 @@ body.dialog-aberto {
     }
   }
 
-  // Alvos de toque adequados (≥ 44px) para uso em tablet: botões de ação de
-  // linha das tabelas e controles de paginação, que no desktop usam 32px.
-  // Cobre tanto as ações agrupadas em `.acoes` quanto as postas direto na
-  // célula `.acoes-cell` (ex.: aula-list, sem `.acoes` interno).
+  // Alvos de toque adequados (≥ 44px) para todos os botões de ação de linha
+  // (issue #162): `.btn-sm` aparece tanto em tabelas (`.acoes`/`.acoes-cell`)
+  // quanto nos cards de sessões, planos de tratamento, reavaliações, NFSEs,
+  // pagamentos e planos — contêineres com nomes próprios que não seriam
+  // cobertos por um seletor restrito a `.table .acoes`/`.acoes-cell`. Por
+  // isso o alvo é a própria classe `.btn-sm`, sem depender do contêiner. O
+  // padding horizontal maior aumenta a área de toque efetiva, mantendo o
+  // `gap` de --sp-2 (8px) já usado entre botões vizinhos.
+  .btn-sm {
+    min-height: 44px;
+    padding: 0 var(--sp-4);
+  }
+
   .table .acoes .btn,
-  .table .acoes .btn-sm,
-  .table .acoes-cell .btn,
-  .table .acoes-cell .btn-sm {
+  .table .acoes-cell .btn {
     min-height: 44px;
   }
 


### PR DESCRIPTION
## Resumo
- A regra de alvo de toque ≥44px passa a mirar diretamente a classe `.btn-sm` em `@media (max-width: 1024px)`, em vez de ficar restrita a `.table .acoes`/`.acoes-cell`
- Remove overrides locais duplicados de `.btn-sm` (padding menor, com especificidade maior por causa do encapsulamento de estilos do Angular) em `aula-list`, `pagamento-list` e `plano-list`, que bloqueavam o padding maior do mobile
- `plano-list`: `gap` de `.acoes-col` alinhado a `--sp-2` (8px), como os demais
- **Consolidada com a PR #184** (branch `fix/165-login-viewport-mobile`): troca `min-height: 100vh` por `100dvh` (com fallback, descontando as margens de `main.container`) nos containers de login/esqueci-senha/resetar-senha, centraliza o card via `margin: auto` para permitir scroll até o botão quando o teclado virtual reduz o viewport, tira o toggle de tema do `position: absolute` (evitando sobreposição em telas baixas) e garante `min-height: 44px` nos botões de submit — ambas as PRs tratam de alvo de toque/mobile, então foram unidas nesta branch

## Motivo
A correção anterior (#123) só cobria os botões dentro de `.table .acoes`/`.acoes-cell`. As telas de sessões, planos de tratamento, reavaliações, NFSEs, pagamentos e planos usam layouts em card ou `<td>` com classes próprias (`.sessao-acoes`, `.plano-acoes`, `.reavaliacao-acoes`, `.nfse-acoes`, `.acoes-col`, ou `<td>` sem classe), então continuavam com botões de 32px de altura no mobile — o problema relatado na issue #162.

Em paralelo, a issue #165 relatava que em mobile `100vh` inclui a área atrás da barra de URL do navegador, e a centralização vertical forçada podia esconder o botão "Entrar" atrás do teclado virtual sem permitir rolagem até ele.

Closes #162
Closes #165

## Testes executados
- [x] `npm run lint` — sem problemas
- [x] `npm run test:ci` — 783/783 testes passando
- [x] `npm run build` — build de produção concluído sem erros
- [x] Validação manual via DevTools/CSSOM no Chrome: simulando a media query `(max-width: 1024px)`, os botões `.btn-sm` em três estruturas de contêiner diferentes (`.table .acoes-cell .acoes`, `.reavaliacao-acoes`, `.acoes-col`) renderizam com `min-height: 44px` e padding horizontal de 16px; fora da media query, mantêm os 32px atuais (desktop inalterado)
- [x] Validação manual das telas de auth (login/esqueci-senha/resetar-senha): varredura de alturas de 900px a 380px em 375px de largura sem overflow residual nem sobreposição do toggle de tema com o card (herdado da revisão original da PR #184)

## Arquivos principais alterados
- `src/styles.scss` — regra de 44px agora mira `.btn-sm` diretamente, sem escopo de contêiner
- `src/app/pages/aulas/aula-list/aula-list.component.scss` — remove override local de `.btn-sm`
- `src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss` — remove override local de `.btn-sm`
- `src/app/pages/planos/plano-list/plano-list.component.scss` — remove override local de `.btn-sm`; `gap` do `.acoes-col` alinhado a `--sp-2`
- `src/app/pages/auth/login/login.component.scss` — 100dvh, margin auto no card, min-height 44px no botão, toggle fora do position absolute
- `src/app/pages/auth/forgot-password/forgot-password.component.scss` — mesma correção (mesmo container `.auth-container`)
- `src/app/pages/auth/reset-password/reset-password.component.scss` — mesma correção (mesmo container `.auth-container`)

## Referência
Issue: #162 — Mobile: alvos de toque abaixo de 44px nos botões de ação de linha (.btn-sm) e ações das tabelas
Issue: #165 — Mobile: tela de login usa min-height 100vh — com teclado aberto o botão Entrar pode ficar oculto sem indicação
