### PR TITLE
feat: exibir nome do paciente no cabeçalho de Planos, Pagamentos e Aulas

### DIFF
--- a/src/app/pages/aulas/aula-list/aula-list.component.html
+++ b/src/app/pages/aulas/aula-list/aula-list.component.html
@@ -1,5 +1,8 @@
 <div class="page-header">
-  <h1>{{ titulo }}</h1>
+  <div>
+    <h1>{{ titulo }}</h1>
+    <p *ngIf="subtitulo" class="page-subtitle">{{ subtitulo }}</p>
+  </div>
   <a *ngIf="pacienteId !== null" [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>
   <a *ngIf="pagamentoId !== null && pacienteId !== null" [routerLink]="['/pagamentos/paciente', pacienteId]" class="btn btn-outline">Voltar aos Pagamentos</a>
 </div>

--- a/src/app/pages/aulas/aula-list/aula-list.component.scss
+++ b/src/app/pages/aulas/aula-list/aula-list.component.scss
@@ -1,3 +1,4 @@
+.page-subtitle { margin-top: var(--sp-2); color: var(--text-secondary); }
 .badge { padding: 2px 10px; border-radius: var(--radius); font-size: 0.85rem; font-weight: 600; }
 .badge-realizada { background: var(--c-success-bg); color: var(--c-success); }
 .badge-pendente { background: var(--bg-sunken); color: var(--text-light); }

--- a/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.spec.ts
@@ -111,6 +111,21 @@ describe('AulaListComponent', () => {
       expect(component.loading).toBeFalse();
     });
 
+    it('should show the paciente name from the DTO as subtitle in the header', () => {
+      expect(component.subtitulo).toBe('Ana Silva');
+      const subtitle: HTMLElement = fixture.nativeElement.querySelector('.page-header .page-subtitle');
+      expect(subtitle).toBeTruthy();
+      expect(subtitle.textContent?.trim()).toBe('Ana Silva');
+    });
+
+    it('should fall back to the generic title when there are no aulas', () => {
+      serviceSpy.listarPorPaciente.and.returnValue(of([]));
+      component.carregar();
+      fixture.detectChanges();
+      expect(component.subtitulo).toBeNull();
+      expect(fixture.nativeElement.querySelector('.page-subtitle')).toBeNull();
+    });
+
     it('should set erro when profissionais fail to load', () => {
       profissionalServiceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
       component.carregarProfissionais();
@@ -273,6 +288,13 @@ describe('AulaListComponent', () => {
       expect(profissionalServiceSpy.listar).toHaveBeenCalledWith(0, 100);
       expect(component.pacienteId).toBe(10);
       expect(component.titulo).toBe('Aulas do Pagamento');
+    });
+
+    it('should show the payment reference and paciente name as subtitle', () => {
+      expect(component.subtitulo).toBe('Pagamento #1 · Ana Silva');
+      const subtitle: HTMLElement = fixture.nativeElement.querySelector('.page-header .page-subtitle');
+      expect(subtitle).toBeTruthy();
+      expect(subtitle.textContent?.trim()).toBe('Pagamento #1 · Ana Silva');
     });
 
     it('should set erro when buscar payment fails', () => {

--- a/src/app/pages/aulas/aula-list/aula-list.component.ts
+++ b/src/app/pages/aulas/aula-list/aula-list.component.ts
@@ -31,6 +31,7 @@ export class AulaListComponent implements OnInit, OnDestroy {
   erro: string | null = null;
   sucesso: string | null = null;
   titulo = 'Aulas';
+  subtitulo: string | null = null;
   private successTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
@@ -68,6 +69,10 @@ export class AulaListComponent implements OnInit, OnDestroy {
       this.pagamentoService.buscar(this.pagamentoId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
         next: pagamento => {
           this.pacienteId = pagamento.pacienteId;
+          // Referência do pagamento + nome do paciente no cabeçalho (issue #143).
+          this.subtitulo = pagamento.pacienteNome
+            ? `Pagamento #${pagamento.id} · ${pagamento.pacienteNome}`
+            : `Pagamento #${pagamento.id}`;
           this.carregar();
         },
         error: () => {
@@ -114,6 +119,11 @@ export class AulaListComponent implements OnInit, OnDestroy {
     request$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: aulas => {
         this.aulas = aulas;
+        // Rota por paciente: nome vem do DTO da aula (issue #143). Na rota por pagamento o
+        // subtítulo já foi definido com a referência do pagamento e não deve ser sobrescrito.
+        if (this.pagamentoId === null) {
+          this.subtitulo = aulas[0]?.pacienteNome ?? null;
+        }
         this.profissionalSelecionadoPorAula = aulas.reduce<Record<number, number | null>>((acc, aula) => {
           acc[aula.id] = aula.profissionalId ?? null;
           return acc;

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.html
@@ -1,5 +1,8 @@
 <div class="page-header">
-  <h1>Pagamentos do Paciente</h1>
+  <div>
+    <h1>Pagamentos do Paciente</h1>
+    <p *ngIf="pacienteNome" class="page-subtitle">{{ pacienteNome }}</p>
+  </div>
   <div class="acoes">
     <a [routerLink]="['/pagamentos/novo', pacienteId]" class="btn btn-primary">Novo Pagamento</a>
     <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.scss
@@ -1,3 +1,4 @@
+.page-subtitle { margin-top: var(--sp-2); color: var(--text-secondary); }
 .badge { padding: 2px 10px; border-radius: var(--radius); font-size: 0.85rem; font-weight: 600; }
 .badge-pendente { background: var(--c-warning-bg); color: var(--c-warning); }
 .badge-pago { background: var(--c-success-bg); color: var(--c-success); }

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.spec.ts
@@ -65,6 +65,21 @@ describe('PagamentoListComponent', () => {
     expect(component.pagamentos).toEqual([mockPagamento]);
   });
 
+  it('should show the paciente name from the DTO as subtitle in the header', () => {
+    expect(component.pacienteNome).toBe('Ana Silva');
+    const subtitle: HTMLElement = fixture.nativeElement.querySelector('.page-header .page-subtitle');
+    expect(subtitle).toBeTruthy();
+    expect(subtitle.textContent?.trim()).toBe('Ana Silva');
+  });
+
+  it('should fall back to the generic title when there are no pagamentos', () => {
+    serviceSpy.listar.and.returnValue(of([]));
+    component.carregar();
+    fixture.detectChanges();
+    expect(component.pacienteNome).toBeNull();
+    expect(fixture.nativeElement.querySelector('.page-subtitle')).toBeNull();
+  });
+
   it('should set erro when listar fails', () => {
     serviceSpy.listar.and.returnValue(throwError(() => new Error('fail')));
     component.carregar();

--- a/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
+++ b/src/app/pages/pagamentos/pagamento-list/pagamento-list.component.ts
@@ -17,6 +17,7 @@ import { ConfirmarDialogComponent } from '../../../shared/components/confirmar-d
 })
 export class PagamentoListComponent implements OnInit, OnDestroy {
   pacienteId: number | null = null;
+  pacienteNome: string | null = null;
   pagamentos: PagamentoResponseDTO[] = [];
   loading = false;
   erro: string | null = null;
@@ -66,6 +67,8 @@ export class PagamentoListComponent implements OnInit, OnDestroy {
     this.service.listar(this.pacienteId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: pagamentos => {
         this.pagamentos = pagamentos;
+        // Nome do paciente vem do próprio DTO (issue #143); lista vazia mantém o título genérico.
+        this.pacienteNome = pagamentos[0]?.pacienteNome ?? null;
         this.loading = false;
         this.cdr.markForCheck();
       },

--- a/src/app/pages/planos/plano-list/plano-list.component.html
+++ b/src/app/pages/planos/plano-list/plano-list.component.html
@@ -1,5 +1,8 @@
 <div class="page-header">
-  <h1>Planos do Paciente</h1>
+  <div>
+    <h1>Planos do Paciente</h1>
+    <p *ngIf="pacienteNome" class="page-subtitle">{{ pacienteNome }}</p>
+  </div>
   <div class="acoes">
     <a [routerLink]="['/planos/novo', pacienteId]" class="btn btn-primary">Novo Plano</a>
     <a [routerLink]="['/pacientes', pacienteId]" class="btn btn-outline">Voltar ao Paciente</a>

--- a/src/app/pages/planos/plano-list/plano-list.component.scss
+++ b/src/app/pages/planos/plano-list/plano-list.component.scss
@@ -1,3 +1,8 @@
+.page-subtitle {
+  margin-top: var(--sp-2);
+  color: var(--text-secondary);
+}
+
 .badge {
   padding: 2px 10px;
   border-radius: var(--radius);

--- a/src/app/pages/planos/plano-list/plano-list.component.spec.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.spec.ts
@@ -6,7 +6,9 @@ import { Subject, of, throwError } from 'rxjs';
 import { isOnPush } from '../../../../testing/onpush';
 import { PlanoListComponent } from './plano-list.component';
 import { PlanoService } from '../../../core/services/plano.service';
+import { PacienteService } from '../../../core/services/paciente.service';
 import { PlanoResponseDTO } from '../../../core/models/plano';
+import { PacienteResponseDTO } from '../../../core/models/paciente';
 
 const mockPlano: PlanoResponseDTO = {
   id: 1, pacienteId: 10, tipo: 'MENSAL', valor: 250,
@@ -14,19 +16,28 @@ const mockPlano: PlanoResponseDTO = {
   diasSemana: ['MONDAY', 'WEDNESDAY'], ativo: true
 };
 
+const mockPaciente: PacienteResponseDTO = {
+  id: 10, nome: 'Ana Silva', email: 'ana@example.com', cpf: '123.456.789-00',
+  telefone: '(11) 90000-0000', dataNascimento: '1990-01-01', endereco: null, ativo: true
+};
+
 describe('PlanoListComponent', () => {
   let component: PlanoListComponent;
   let fixture: ComponentFixture<PlanoListComponent>;
   let serviceSpy: jasmine.SpyObj<PlanoService>;
+  let pacienteServiceSpy: jasmine.SpyObj<PacienteService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('PlanoService', ['listar', 'inativar']);
     serviceSpy.listar.and.returnValue(of([mockPlano]));
+    pacienteServiceSpy = jasmine.createSpyObj('PacienteService', ['buscar']);
+    pacienteServiceSpy.buscar.and.returnValue(of(mockPaciente));
 
     await TestBed.configureTestingModule({
       imports: [PlanoListComponent, RouterTestingModule],
       providers: [
         { provide: PlanoService, useValue: serviceSpy },
+        { provide: PacienteService, useValue: pacienteServiceSpy },
         { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '10' } } } }
       ]
     }).compileComponents();
@@ -63,6 +74,25 @@ describe('PlanoListComponent', () => {
     expect(serviceSpy.listar).toHaveBeenCalledWith(10);
     expect(component.planos).toEqual([mockPlano]);
     expect(component.loading).toBeFalse();
+  });
+
+  it('should show the paciente name as subtitle in the header', () => {
+    expect(pacienteServiceSpy.buscar).toHaveBeenCalledWith(10);
+    expect(component.pacienteNome).toBe('Ana Silva');
+    const subtitle: HTMLElement = fixture.nativeElement.querySelector('.page-header .page-subtitle');
+    expect(subtitle).toBeTruthy();
+    expect(subtitle.textContent?.trim()).toBe('Ana Silva');
+  });
+
+  it('should keep the generic title when the paciente name fails to load', () => {
+    pacienteServiceSpy.buscar.and.returnValue(throwError(() => new Error('fail')));
+    component.pacienteNome = null;
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(component.pacienteNome).toBeNull();
+    expect(component.erro).toBeNull();
+    expect(component.planos).toEqual([mockPlano]);
+    expect(fixture.nativeElement.querySelector('.page-subtitle')).toBeNull();
   });
 
   it('should set erro when listar fails', () => {
@@ -118,13 +148,15 @@ describe('PlanoListComponent', () => {
 
   it('should not load planos when pacienteId route param is invalid', () => {
     const invalidServiceSpy = jasmine.createSpyObj('PlanoService', ['listar', 'inativar']);
+    const invalidPacienteServiceSpy = jasmine.createSpyObj('PacienteService', ['buscar']);
     const invalidRoute = { snapshot: { paramMap: convertToParamMap({ pacienteId: 'abc' }) } } as ActivatedRoute;
-    const invalidComponent = new PlanoListComponent(invalidServiceSpy, invalidRoute, { markForCheck: () => {} } as ChangeDetectorRef, { onDestroy: () => () => {} } as DestroyRef);
+    const invalidComponent = new PlanoListComponent(invalidServiceSpy, invalidPacienteServiceSpy, invalidRoute, { markForCheck: () => {} } as ChangeDetectorRef, { onDestroy: () => () => {} } as DestroyRef);
 
     invalidComponent.ngOnInit();
 
     expect(invalidComponent.erro).toBe('Identificador inválido.');
     expect(invalidServiceSpy.listar).not.toHaveBeenCalled();
+    expect(invalidPacienteServiceSpy.buscar).not.toHaveBeenCalled();
   });
 
   it('should not fire a second inativar request while the action is in progress', () => {

--- a/src/app/pages/planos/plano-list/plano-list.component.ts
+++ b/src/app/pages/planos/plano-list/plano-list.component.ts
@@ -3,6 +3,7 @@ import { CurrencyPipe, DatePipe, NgFor, NgIf } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { PlanoService } from '../../../core/services/plano.service';
+import { PacienteService } from '../../../core/services/paciente.service';
 import { PlanoResponseDTO, TIPO_LABEL, FREQUENCIA_LABEL, DIAS_SEMANA_LABEL } from '../../../core/models/plano';
 import { parseRouteNumberParam } from '../../../shared/utils/route-param';
 import { ConfirmarDialogComponent } from '../../../shared/components/confirmar-dialog/confirmar-dialog.component';
@@ -16,6 +17,7 @@ import { ConfirmarDialogComponent } from '../../../shared/components/confirmar-d
 })
 export class PlanoListComponent implements OnInit, OnDestroy {
   pacienteId: number | null = null;
+  pacienteNome: string | null = null;
   planos: PlanoResponseDTO[] = [];
   loading = false;
   erro: string | null = null;
@@ -28,7 +30,7 @@ export class PlanoListComponent implements OnInit, OnDestroy {
   readonly frequenciaLabel = FREQUENCIA_LABEL;
   readonly diasLabel = DIAS_SEMANA_LABEL;
 
-  constructor(private service: PlanoService, private route: ActivatedRoute, private cdr: ChangeDetectorRef, private destroyRef: DestroyRef) {}
+  constructor(private service: PlanoService, private pacienteService: PacienteService, private route: ActivatedRoute, private cdr: ChangeDetectorRef, private destroyRef: DestroyRef) {}
 
   ngOnInit(): void {
     this.pacienteId = parseRouteNumberParam(this.route.snapshot.paramMap, 'pacienteId');
@@ -36,7 +38,20 @@ export class PlanoListComponent implements OnInit, OnDestroy {
       this.erro = 'Identificador inválido.';
       return;
     }
+    this.carregarNomePaciente();
     this.carregar();
+  }
+
+  private carregarNomePaciente(): void {
+    if (this.pacienteId === null) return;
+    this.pacienteService.buscar(this.pacienteId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: paciente => {
+        this.pacienteNome = paciente.nome;
+        this.cdr.markForCheck();
+      },
+      // Falha ao carregar o nome não bloqueia a listagem (issue #143): mantém o título genérico.
+      error: () => { this.pacienteNome = null; }
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Resumo

Adiciona o nome do paciente como subtítulo (`page-subtitle`) no cabeçalho das quatro rotas que hoje exibem apenas títulos genéricos, replicando o padrão visual já usado na tela de Sessões:

- `/planos/paciente/:pacienteId`
- `/pagamentos/paciente/:pacienteId`
- `/aulas/paciente/:pacienteId`
- `/aulas/pagamento/:pagamentoId` → exibe também a referência do pagamento: **"Pagamento #{id} · {nome}"**

## Motivo

Os títulos genéricos ("Planos do Paciente", "Pagamentos do Paciente", "Aulas do Paciente") não indicavam **de qual paciente** se tratava. No fluxo típico da recepção, navegando entre vários cadastros, isso faz perder o contexto e cria risco de registrar um pagamento no paciente errado. Ver issue #143.

## Como o dado é obtido (sem endpoint novo)

- **Planos:** `PlanoResponseDTO` não traz o nome → busca via `GET /api/pacientes/{id}` (`PacienteService.buscar`), de forma **não bloqueante**: se a busca do nome falhar, a listagem continua e o título genérico é mantido.
- **Pagamentos** e **Aulas (por paciente):** nome vindo do campo `pacienteNome` já presente em `PagamentoResponseDTO` / `AulaResponseDTO` (zero requisições extras). Lista vazia mantém o título genérico.
- **Aulas (por pagamento):** subtítulo montado a partir do `PagamentoResponseDTO` já carregado para resolver o `pacienteId`.

## Critérios de aceite

- [x] Nome do paciente visível no cabeçalho das quatro rotas
- [x] Falha ao carregar o nome não bloqueia a listagem (fallback para o título genérico)
- [x] Padrão visual idêntico ao subtítulo da tela de Sessões
- [x] Testes unitários atualizados

## Testes executados

- `npm run lint` → All files pass linting
- `npm run test:ci` → **790 SUCCESS** (inclui novos testes de subtítulo e fallback)
- `npm run build` → build de produção concluído com sucesso

## Arquivos principais alterados

- `plano-list.component.{ts,html,scss,spec.ts}` — injeta `PacienteService`, subtítulo não bloqueante
- `pagamento-list.component.{ts,html,scss,spec.ts}` — subtítulo a partir do DTO
- `aula-list.component.{ts,html,scss,spec.ts}` — subtítulo por paciente e referência do pagamento

Refs #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUpgGbck4NpXxCzFecHvRK)_