### PR TITLE
fix: diálogo responsivo em telas estreitas no mobile (#166)

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -480,6 +480,10 @@ select.form-control,
   display: flex;
   align-items: center;
   justify-content: center;
+  // Respiro lateral em qualquer largura: garante margem entre o diálogo e as
+  // bordas da viewport mesmo em telas estreitas (~320px). Com box-sizing:
+  // border-box o padding não estoura o overlay fixo (issue #166).
+  padding: var(--sp-4);
   z-index: 999;
 }
 
@@ -493,7 +497,10 @@ body.dialog-aberto {
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
   padding: var(--sp-6);
-  min-width: 320px;
+  // Em telas mais largas mantém os 320px de largura mínima; abaixo de ~340px
+  // recua para caber na viewport descontando o padding do overlay (2×16px),
+  // evitando que o conteúdo encoste/estoure as bordas (issue #166).
+  min-width: min(320px, calc(100vw - 32px));
   box-shadow: var(--shadow-3);
 
   p {
@@ -718,5 +725,18 @@ body.dialog-aberto {
   .textarea,
   .form-control-sm {
     font-size: 16px;
+  }
+
+  // Ações dos diálogos no mobile: os botões crescem para dividir a linha e,
+  // quando não cabem lado a lado (rótulos longos em ~320px), quebram para
+  // ocupar a largura toda empilhados. O min-height garante alvo de toque
+  // confortável (≥ 44px) com o teclado fechado (issue #166).
+  .dialog-actions {
+    flex-wrap: wrap;
+
+    .btn {
+      flex: 1 1 auto;
+      min-height: 44px;
+    }
   }
 }


### PR DESCRIPTION
## Resumo

Corrige o estouro dos diálogos (`ConfirmarDialogComponent` e `.dialog` global) em viewports estreitas (~320px), garantindo margem lateral e alvos de toque confortáveis no mobile. Fix somente CSS.

## Motivo

O `.dialog` global usava `min-width: 320px` em unidade fixa e o `.dialog-overlay` não tinha padding. Abaixo de ~340px (ex.: iPhone SE 1ª ger., Galaxy Fold fechado) o diálogo ocupava 100% da largura colado às bordas, e conteúdos mais largos (lista de detalhes da confirmação de aula, formulário do diálogo de pagamento) podiam estourar a viewport. Ref.: issue #166.

## Alteração

- **`.dialog`**: `min-width: min(320px, calc(100vw - 32px))` — mantém 320px no desktop e recua para caber quando a viewport é menor, descontando o padding do overlay.
- **`.dialog-overlay`**: adiciona `padding: var(--sp-4)` (16px) para respiro lateral em qualquer largura. Com `box-sizing: border-box` o overlay fixo não estoura.
- **Mobile (≤768px)**: as ações do diálogo (`.dialog-actions .btn`) crescem para dividir a linha, quebram para largura total quando os rótulos não cabem lado a lado e mantêm `min-height: 44px` (alvo de toque).

O `max-width: 480px` do componente permanece inalterado, e a lógica de focus trap / Esc / clique-fora não foi tocada. Mudanças são theme-agnostic (usam tokens + viewport), preservando temas claro/escuro.

## Testes executados

- `npm run lint` — All files pass linting ✅
- `npm run build` — Application bundle generation complete ✅
- `npm run test:ci` — 819 SUCCESS ✅
- Verificação visual (Chromium headless) com rótulos longos:
  - 320px → margem lateral 16px, sem overflow, botões 44px empilhados
  - 375px → margem lateral 16px, sem overflow, botões 44px empilhados
  - 414px → sem overflow, botões 44px lado a lado (cabem)

## Critérios de aceite

- [x] Em 320/375/414px o diálogo tem margem lateral visível e nenhum conteúdo cortado
- [x] Diálogo de confirmação (detalhes projetados) e formulário de pagamento cobertos pelo componente compartilhado
- [x] Botões alcançáveis e com toque confortável (≥44px) com teclado fechado
- [x] Focus trap, Esc e clique-fora preservados (lógica intocada)
- [x] Temas claro/escuro preservados

## Arquivos principais alterados

- `src/styles.scss` — regras `.dialog`, `.dialog-overlay` e ações do diálogo no mobile

## Issue

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYYfLmQcxsZvXeAja1b6A2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYYfLmQcxsZvXeAja1b6A2)_